### PR TITLE
Fix sum of category combos

### DIFF
--- a/lib/orbf/rules_engine/builders/activity_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/activity_variables_builder.rb
@@ -120,8 +120,8 @@ module Orbf
           next unless vals
           if vals.size == 1
             return ValueLookup.new(value: vals.first["value"], is_null: false)
-          else vals.size > 1
-            return ValueLookup.new(value: vals.map { |v| v["value"] }.join(" + "), is_null: false)
+          elsif vals.size > 1
+            return ValueLookup.new(value: vals.map { |v| v["value"] }.compact.join(" + "), is_null: false)
           end
         end
         ValueLookup.new(value: "0", is_null: true)

--- a/lib/orbf/rules_engine/builders/activity_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/activity_variables_builder.rb
@@ -118,10 +118,11 @@ module Orbf
         keys.each do |key|
           vals = lookup[key]
           next unless vals
+          vals = vals.map { |v| v["value"] }.compact
           if vals.size == 1
-            return ValueLookup.new(value: vals.first["value"], is_null: false)
+            return ValueLookup.new(value: vals.first, is_null: false)
           elsif vals.size > 1
-            return ValueLookup.new(value: vals.map { |v| v["value"] }.compact.join(" + "), is_null: false)
+            return ValueLookup.new(value: vals.join(" + "), is_null: false)
           end
         end
         ValueLookup.new(value: "0", is_null: true)

--- a/lib/orbf/rules_engine/builders/activity_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/activity_variables_builder.rb
@@ -89,6 +89,7 @@ module Orbf
         parents_with_level.each do |hash|
           code = "#{activity_state.state}_level_#{hash[:level]}"
           next unless dependencies.include?(code)
+
           hash_value = lookup_value(build_keys_with_yearly([hash[:id], period, activity_state.ext_id]))
           yield(hash[:id], code, hash_value)
         end
@@ -97,6 +98,7 @@ module Orbf
       def main_orgunit_values(activity_state, period, dependencies)
         code = "#{activity_state.state}_zone_main_orgunit"
         return unless dependencies.include?(code)
+
         main_orgunit_ext_id = orgunits.first.ext_id
         key = [main_orgunit_ext_id, period, activity_state.ext_id]
         hash_value = lookup_value(build_keys_with_yearly(key))
@@ -118,6 +120,7 @@ module Orbf
         keys.each do |key|
           vals = lookup[key]
           next unless vals
+
           vals = vals.map { |v| v["value"] }.compact
           if vals.size == 1
             return ValueLookup.new(value: vals.first, is_null: false)

--- a/lib/orbf/rules_engine/builders/activity_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/activity_variables_builder.rb
@@ -116,8 +116,13 @@ module Orbf
 
       def lookup_value(keys)
         keys.each do |key|
-          val = lookup[key]
-          return ValueLookup.new(value: val.first["value"], is_null: false) if val
+          vals = lookup[key]
+          next unless vals
+          if vals.size == 1
+            return ValueLookup.new(value: vals.first["value"], is_null: false)
+          else vals.size > 1
+            return ValueLookup.new(value: vals.map { |v| v["value"] }.join(" + "), is_null: false)
+          end
         end
         ValueLookup.new(value: "0", is_null: true)
       end

--- a/lib/orbf/rules_engine/builders/indicator_evaluator.rb
+++ b/lib/orbf/rules_engine/builders/indicator_evaluator.rb
@@ -6,10 +6,10 @@ module Orbf
       include VariablesBuilderSupport
 
       def initialize(indicators, dhis2_values)
-        @indicators = Array(indicators)
+        @indicators = Array(indicators).uniq
         @indexed_values = Dhis2IndexedValues.new(dhis2_values)
         @period_orgunits = dhis2_values.map do |value|
-          [value['period'], value['org_unit'] || value['orgUnit']]
+          [value["period"], value["org_unit"] || value["orgUnit"]]
         end
 
         @period_orgunits = @period_orgunits.uniq
@@ -28,17 +28,19 @@ module Orbf
         @period_orgunits.map do |period, orgunit|
           value = indicator_value(period, orgunit, parsed_expressions)
           {
-             'dataElement'         => indicator.ext_id,
-            'categoryOptionCombo' => 'default',
-            'value'               => ValueFormatter.format(value).to_s,
-            'period'              => period,
-            'orgUnit'             => orgunit
-           }
+            "dataElement"         => indicator.ext_id,
+            "categoryOptionCombo" => "default",
+            "value"               => value,
+            "period"              => period,
+            "orgUnit"             => orgunit
+          }
         end
       end
 
       def sum_values(values)
-        values.inject(0) { |sum, v| sum + v['value'].to_f }
+        return "0" if values.empty?
+
+        values.map { |v| v["value"] }.join(" + ")
       end
 
       def indicator_value(period, orgunit, parsed_expressions)

--- a/spec/lib/orbf/rules_engine/builders/activity_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/activity_variables_builder_spec.rb
@@ -536,7 +536,11 @@ RSpec.describe Orbf::RulesEngine::ActivityVariablesBuilder do
           Orbf::RulesEngine::Rule.new(
             kind:     :activity,
             formulas: [
-              Orbf::RulesEngine::Formula.new("allowed", "cap", "")
+              Orbf::RulesEngine::Formula.new("allowed", "cap", ""),
+              Orbf::RulesEngine::Formula.new(
+                "cap_check",
+                "if(cap_is_null=1,4,7)"
+              )
             ]
           )
         ]
@@ -565,6 +569,18 @@ RSpec.describe Orbf::RulesEngine::ActivityVariablesBuilder do
             formula:        nil,
             package:        package,
             payment_rule:   nil
+          ),
+          Orbf::RulesEngine::Variable.with(
+            period:         "2016",
+            key:            "facility_act1_cap_is_null_for_2_and_2016",
+            expression:     "0",
+            state:          "cap_is_null",
+            activity_code:  "act1",
+            type:           "activity",
+            orgunit_ext_id: "2",
+            formula:        nil,
+            package:        package,
+            payment_rule:   nil
           )
         ]
       end
@@ -579,7 +595,7 @@ RSpec.describe Orbf::RulesEngine::ActivityVariablesBuilder do
       end
     end
 
-    describe "sums category combos values and remove nil one" do
+    describe "default to 0 when all dhis2 values are nil" do
       let(:dhis2_values) do
         [
           { "dataElement" => "dhis2_act1_cap", "categoryOptionCombo" => "1to4", "value" => nil, "period" => "2016", "orgUnit" => "2", "comment" => "" },
@@ -595,6 +611,18 @@ RSpec.describe Orbf::RulesEngine::ActivityVariablesBuilder do
             key:            "facility_act1_cap_for_2_and_2016",
             expression:     "0",
             state:          "cap",
+            activity_code:  "act1",
+            type:           "activity",
+            orgunit_ext_id: "2",
+            formula:        nil,
+            package:        package,
+            payment_rule:   nil
+          ),
+          Orbf::RulesEngine::Variable.with(
+            period:         "2016",
+            key:            "facility_act1_cap_is_null_for_2_and_2016",
+            expression:     "1",
+            state:          "cap_is_null",
             activity_code:  "act1",
             type:           "activity",
             orgunit_ext_id: "2",

--- a/spec/lib/orbf/rules_engine/builders/activity_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/activity_variables_builder_spec.rb
@@ -508,4 +508,73 @@ RSpec.describe Orbf::RulesEngine::ActivityVariablesBuilder do
       expect(result).to eq_vars(expected_vars)
     end
   end
+
+  context "data elements with multiple category combo" do
+    let(:activities) do
+      [
+        Orbf::RulesEngine::Activity.with(
+          name:            "act1",
+          activity_code:   "act1",
+          activity_states: [
+            Orbf::RulesEngine::ActivityState.new_data_element(
+              state:  :cap,
+              ext_id: "dhis2_act1_cap",
+              name:   "act1_cap"
+            )
+          ]
+        )
+      ]
+    end
+
+    let(:package) do
+      Orbf::RulesEngine::Package.new(
+        code:            :facility,
+        kind:            :single,
+        frequency:       :quarterly,
+        activities:      activities,
+        rules:           [
+          Orbf::RulesEngine::Rule.new(
+            kind:     :activity,
+            formulas: [
+              Orbf::RulesEngine::Formula.new("allowed", "cap", "")
+            ]
+          )
+        ]
+      )
+    end
+
+    let(:dhis2_values) do
+      [
+        { "dataElement" => "dhis2_act1_cap", "categoryOptionCombo" => "1to4", "value" => "33", "period" => "2016", "orgUnit" => "2", "comment" => "" },
+        { "dataElement" => "dhis2_act1_cap", "categoryOptionCombo" => "5to20", "value" => nil, "period" => "2016", "orgUnit" => "2", "comment" => "" },
+        { "dataElement" => "dhis2_act1_cap", "categoryOptionCombo" => "morethan20", "value" => "12", "period" => "2016", "orgUnit" => "2", "comment" => "" }
+      ]
+    end
+
+    let(:expected_vars) do
+      [
+       Orbf::RulesEngine::Variable.with(
+          period:         "2016",
+          key:            "facility_act1_cap_for_2_and_2016",
+          expression:     "33 + 12",
+          state:          "cap",
+          activity_code:  "act1",
+          type:           "activity",
+          orgunit_ext_id: "2",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        )
+      ]
+    end
+
+    it "registers activity_variables" do
+      result = described_class.new(
+        package,
+        Orbf::RulesEngine::OrgUnits.new(orgunits: [orgunits.last], package: package),
+        dhis2_values
+      ).convert("2016")
+      expect(result).to eq_vars(expected_vars)
+    end
+  end
 end

--- a/spec/lib/orbf/rules_engine/builders/indicator_evaluator_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/indicator_evaluator_spec.rb
@@ -37,16 +37,21 @@ RSpec.describe Orbf::RulesEngine::IndicatorEvaluator do
         { "dataElement" => "dhis2_act1_achieved", "categoryOptionCombo" => "default",
            "value" => "33", "period" => "2016Q1", "orgUnit" => "1" },
         { "dataElement" => "dhis2_act1_target",   "categoryOptionCombo" => "default",
-          "value" => "67", "period" => "2016Q1", "orgUnit" => "1" },
+          "value" => "33 + 34", "period" => "2016Q1", "orgUnit" => "1" },
         { "dataElement" => "dhis2_act1_achieved", "categoryOptionCombo" => "default",
            "value" => "3", "period" => "2016Q1", "orgUnit" => "2" },
         { "dataElement" => "dhis2_act1_target",   "categoryOptionCombo" => "default",
-          "value" => "27", "period" => "2016Q1", "orgUnit" => "2" }
+          "value" => "3 + 24", "period" => "2016Q1", "orgUnit" => "2" }
       ]
     end
 
     it "computer DHIS2 values" do
       dhis2_values = described_class.new(indicators, in_dhis2_values).to_dhis2_values
+      expect(dhis2_values).to match_array(expected_dhis2_values)
+    end
+
+    it "doesn't duplicate dhis2_values when indicators pass twice" do
+      dhis2_values = described_class.new(indicators + indicators, in_dhis2_values).to_dhis2_values
       expect(dhis2_values).to match_array(expected_dhis2_values)
     end
 

--- a/spec/senegal_system_spec.rb
+++ b/spec/senegal_system_spec.rb
@@ -126,18 +126,16 @@ RSpec.describe "Senegal System" do
   end
 
   let(:dhis2_values) do
-    [
+    Dhis2ValuesHelper.ensure_valid([
       { "dataElement" => "dhis2_act1_verified", "categoryOptionCombo" => "default", "value" => "33", "period" => "201601", "orgUnit" => "1" },
       { "dataElement" => "dhis2_act2_validated", "categoryOptionCombo" => "default", "value" => "80", "period" => "201601", "orgUnit" => "1" },
-      { "dataElement" => "dhis2_act1_verified", "categoryOptionCombo" => "default", "value" => "41", "period" => "201601", "orgUnit" => "1" },
       { "dataElement" => "dhis2_act1_claimed", "categoryOptionCombo" => "default", "value" => "40", "period" => "201601", "orgUnit" => "1" },
 
       { "dataElement" => "dhis2_act1_claimed", "categoryOptionCombo" => "default", "value" => "12", "period" => "201601", "orgUnit" => "2" },
       { "dataElement" => "dhis2_act2_verified", "categoryOptionCombo" => "default", "value" => "92", "period" => "201601", "orgUnit" => "2" },
       { "dataElement" => "dhis2_act1_verified", "categoryOptionCombo" => "default", "value" => "31", "period" => "201601", "orgUnit" => "2" },
       { "dataElement" => "dhis2_act1_validated", "categoryOptionCombo" => "default", "value" => "37", "period" => "201601", "orgUnit" => "2" }
-
-    ]
+    ])
   end
 
   let(:solver) do

--- a/spec/senegal_system_spec.rb
+++ b/spec/senegal_system_spec.rb
@@ -127,15 +127,14 @@ RSpec.describe "Senegal System" do
 
   let(:dhis2_values) do
     Dhis2ValuesHelper.ensure_valid([
-      { "dataElement" => "dhis2_act1_verified", "categoryOptionCombo" => "default", "value" => "33", "period" => "201601", "orgUnit" => "1" },
-      { "dataElement" => "dhis2_act2_validated", "categoryOptionCombo" => "default", "value" => "80", "period" => "201601", "orgUnit" => "1" },
-      { "dataElement" => "dhis2_act1_claimed", "categoryOptionCombo" => "default", "value" => "40", "period" => "201601", "orgUnit" => "1" },
-
-      { "dataElement" => "dhis2_act1_claimed", "categoryOptionCombo" => "default", "value" => "12", "period" => "201601", "orgUnit" => "2" },
-      { "dataElement" => "dhis2_act2_verified", "categoryOptionCombo" => "default", "value" => "92", "period" => "201601", "orgUnit" => "2" },
-      { "dataElement" => "dhis2_act1_verified", "categoryOptionCombo" => "default", "value" => "31", "period" => "201601", "orgUnit" => "2" },
-      { "dataElement" => "dhis2_act1_validated", "categoryOptionCombo" => "default", "value" => "37", "period" => "201601", "orgUnit" => "2" }
-    ])
+                                     { "dataElement" => "dhis2_act1_verified", "categoryOptionCombo" => "default", "value" => "33", "period" => "201601", "orgUnit" => "1" },
+                                     { "dataElement" => "dhis2_act2_validated", "categoryOptionCombo" => "default", "value" => "80", "period" => "201601", "orgUnit" => "1" },
+                                     { "dataElement" => "dhis2_act1_claimed", "categoryOptionCombo" => "default", "value" => "40", "period" => "201601", "orgUnit" => "1" },
+                                     { "dataElement" => "dhis2_act1_claimed", "categoryOptionCombo" => "default", "value" => "12", "period" => "201601", "orgUnit" => "2" },
+                                     { "dataElement" => "dhis2_act2_verified", "categoryOptionCombo" => "default", "value" => "92", "period" => "201601", "orgUnit" => "2" },
+                                     { "dataElement" => "dhis2_act1_verified", "categoryOptionCombo" => "default", "value" => "31", "period" => "201601", "orgUnit" => "2" },
+                                     { "dataElement" => "dhis2_act1_validated", "categoryOptionCombo" => "default", "value" => "37", "period" => "201601", "orgUnit" => "2" }
+                                   ])
   end
 
   let(:solver) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,6 +20,7 @@ require "webmock/rspec"
 
 require_relative "./support/eq_vars"
 require_relative "./support/dhis2_stubs"
+require_relative "./support/dhis2_values_helper"
 
 require_relative "../lib/orbf/rules_engine"
 

--- a/spec/support/dhis2_values_helper.rb
+++ b/spec/support/dhis2_values_helper.rb
@@ -18,14 +18,15 @@ class Dhis2ValuesHelper
 
     dhis2_values = grouped_values.map do |key, values|
       raise "multiple values for #{key} #{values}" if values.map { |v| v["value"] }.uniq.size > 1
+
       values.first
     end
 
     dhis2_values
   end
 
-    # make sure they are strings and not symbols
-    def self.ensure_strings(raw_dhis2_values)
+  # make sure they are strings and not symbols
+  def self.ensure_strings(raw_dhis2_values)
     JSON.parse(JSON.generate(raw_dhis2_values))
   end
 

--- a/spec/support/dhis2_values_helper.rb
+++ b/spec/support/dhis2_values_helper.rb
@@ -1,0 +1,30 @@
+class Dhis2ValuesHelper
+    def self.ensure_valid(raw_dhis2_values)
+
+        # make sure they are strings and not symbols
+        dhis2_values = JSON.parse(JSON.generate(raw_dhis2_values))
+
+        grouped_values = dhis2_values.group_by {|v| [v["dataElement"], v["orgUnit"], v["period"],v["categoryOptionCombo"]]}
+
+        grouped_values.each do |key, values|
+            raise "non unique values for #{key} : #{values}" if values.size > 1
+        end
+
+        dhis2_values
+    end
+
+    def self.uniq(raw_dhis2_values)
+
+        # make sure they are strings and not symbols
+        dhis2_values = JSON.parse(JSON.generate(raw_dhis2_values))
+
+        grouped_values = dhis2_values.group_by {|v| [v["dataElement"], v["orgUnit"], v["period"],v["categoryOptionCombo"]]}
+
+        dhis2_values = grouped_values.map do |key, values|
+            raise "multiple values for #{key} #{values}" if values.map {|v| v["value"]}.uniq.size > 1
+            values.first
+        end
+
+        dhis2_values
+    end
+end

--- a/spec/support/dhis2_values_helper.rb
+++ b/spec/support/dhis2_values_helper.rb
@@ -1,30 +1,35 @@
 class Dhis2ValuesHelper
-    def self.ensure_valid(raw_dhis2_values)
+  def self.ensure_valid(raw_dhis2_values)
+    dhis2_values = ensure_strings(raw_dhis2_values)
 
-        # make sure they are strings and not symbols
-        dhis2_values = JSON.parse(JSON.generate(raw_dhis2_values))
+    grouped_values = group_by(dhis2_values)
 
-        grouped_values = dhis2_values.group_by {|v| [v["dataElement"], v["orgUnit"], v["period"],v["categoryOptionCombo"]]}
-
-        grouped_values.each do |key, values|
-            raise "non unique values for #{key} : #{values}" if values.size > 1
-        end
-
-        dhis2_values
+    grouped_values.each do |key, values|
+      raise "non unique values for #{key} : #{values}" if values.size > 1
     end
 
-    def self.uniq(raw_dhis2_values)
+    dhis2_values
+  end
 
-        # make sure they are strings and not symbols
-        dhis2_values = JSON.parse(JSON.generate(raw_dhis2_values))
+  def self.uniq(raw_dhis2_values)
+    dhis2_values = ensure_strings(raw_dhis2_values)
 
-        grouped_values = dhis2_values.group_by {|v| [v["dataElement"], v["orgUnit"], v["period"],v["categoryOptionCombo"]]}
+    grouped_values = group_by(dhis2_values)
 
-        dhis2_values = grouped_values.map do |key, values|
-            raise "multiple values for #{key} #{values}" if values.map {|v| v["value"]}.uniq.size > 1
-            values.first
-        end
-
-        dhis2_values
+    dhis2_values = grouped_values.map do |key, values|
+      raise "multiple values for #{key} #{values}" if values.map { |v| v["value"] }.uniq.size > 1
+      values.first
     end
+
+    dhis2_values
+  end
+
+    # make sure they are strings and not symbols
+    def self.ensure_strings(raw_dhis2_values)
+    JSON.parse(JSON.generate(raw_dhis2_values))
+  end
+
+  def self.group_by(dhis2_values)
+    dhis2_values.group_by { |v| [v["dataElement"], v["orgUnit"], v["period"], v["categoryOptionCombo"]] }
+  end
 end

--- a/spec/system_spec.rb
+++ b/spec/system_spec.rb
@@ -248,7 +248,7 @@ RSpec.describe "System" do
   end
 
   let(:dhis2_values) do
-    JSON.parse(JSON.generate((dhis2_orgunit_values + dhis2_country_values).flatten))
+    Dhis2ValuesHelper.ensure_valid(Dhis2ValuesHelper.uniq((dhis2_orgunit_values + dhis2_country_values).flatten))
   end
 
   let(:solver) do


### PR DESCRIPTION
- some spec were failing due to bad fixtures (duplicated values, made them uniq)

- now the engine will compute the sum (instead of summing in ruby), this allow nicer explanation in the simulation page.

![image](https://user-images.githubusercontent.com/371692/46067542-5bc97b00-c177-11e8-8f32-14268cca8fe5.png)

