### PR TITLE
Add rake console

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -4,3 +4,12 @@ require "rspec/core/rake_task"
 RSpec::Core::RakeTask.new(:spec)
 
 task :default => :spec
+
+desc "Open a console with gem already loaded"
+task :console do
+  require "irb"
+  require 'irb/completion'
+  require './lib/orbf/rules_engine'
+  ARGV.clear
+  IRB.start
+end


### PR DESCRIPTION
`bundle exec rake console` will now open an irb with the gem already
loaded, so you can start right away.

It's a small change, but it really ties the room together.
