### PR TITLE
Use concat to fix stack level too deep error

### DIFF
--- a/lib/orbf/rules_engine/services/solver.rb
+++ b/lib/orbf/rules_engine/services/solver.rb
@@ -14,7 +14,7 @@ module Orbf
       end
 
       def register_variables(vars)
-        @variables.push(*vars)
+        @variables.concat(vars)
       end
 
       def build_problem

--- a/spec/lib/orbf/rules_engine/services/solver_spec.rb
+++ b/spec/lib/orbf/rules_engine/services/solver_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe Orbf::RulesEngine::Solver do
         )
         expect { solver.solve! }.to raise_error(Dentaku::UnboundVariableError)
       end
+
+      it "can handle large number of variables" do
+        expect {
+          solver.register_variables(
+            [
+              build_variable("nil_key", nil)
+            ] * 131072
+          )
+        }.to_not raise_error
+      end
     end
   end
 
@@ -87,6 +97,16 @@ RSpec.describe Orbf::RulesEngine::Solver do
           Hesabu::Error,
           "In equation key2 No parameter 'key_missing' found. key2 := key_missing"
         )
+      end
+
+      it "can handle large number of variables" do
+        expect {
+          solver.register_variables(
+            [
+              build_variable("nil_key", nil)
+            ] * 131072
+          )
+        }.to_not raise_error
       end
     end
   end


### PR DESCRIPTION
This was a fun one, in production we ran into an issue where running a particular zone we would get a:

      SystemStackError: stack level too deep

And the backtrace pointed to the `push` line.

Turns out, that ruby has a hard limit on the number of arguments you can give to a function (which is what we do when calling `push(*arr)`), so because this particular zone was generating 300 000
variables, the `push` broke.

Using concat fixes this (and should make memory behave nicer as well).

I tried to figure out what the hard limit is:

      RubyVM::DEFAULT_PARAMS
      # => {
        :thread_vm_stack_size=>1048576,
        :thread_machine_stack_size=>1048576,
        :fiber_vm_stack_size=>131072,
        :fiber_machine_stack_size=>524288
      }

It seems to be the `fiber_vm_stack_size`, you can try this at home with:

      [].push(*Array.new(131072))

Which will fail, but since you're already somewhere in the stack
you'll need to detuct a few hundred to get this to pass.
