### PR TITLE
Use numeric for stdev and sqrt function signature

### DIFF
--- a/lib/orbf/rules_engine/builders/calculator_factory.rb
+++ b/lib/orbf/rules_engine/builders/calculator_factory.rb
@@ -84,8 +84,8 @@ module Orbf
           calculator.add_function(:randbetween, :numeric, RANDBETWEEN)
           calculator.add_function(:eval_array, :array, EVAL_ARRAY)
           calculator.add_function(:array, :array, ARRAY)
-          calculator.add_function(:stdevp, :number, STDEVP)
-          calculator.add_function(:sqrt, :number, SQRT)
+          calculator.add_function(:stdevp, :numeric, STDEVP)
+          calculator.add_function(:sqrt, :numeric, SQRT)
         end
       end
 

--- a/spec/lib/orbf/rules_engine/builders/calculator_factory_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/calculator_factory_spec.rb
@@ -29,6 +29,13 @@ RSpec.describe Orbf::RulesEngine::CalculatorFactory do
         end
       end
 
+      describe "support stdevp function" do
+        it "solve " do
+          solution = calculator.solve("mystdevp" => "round(12 + STDEVP(1,3,9) + sqrt(4) , 2)")
+          expect(solution["mystdevp"].to_f).to eq(17.4)
+        end
+      end
+
       describe "support score table function" do
         [
           [9, 1],


### PR DESCRIPTION
was getting error like : 
 - Formulas expression Dentaku::AST::Addition requires numeric operands, but got number 
 - Formulas Dentaku::AST::Addition requires numeric operands, but got number 

when combining sqrt or stdev in function like : 
`round(price_level_2 +(price_level_2  * category_tarif_boost/100 ),0) + sqrt(16)
`