### PR TITLE
Add support for ..._level_X_quarterly

### DIFF
--- a/lib/orbf/rules_engine/builders/activity_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/activity_variables_builder.rb
@@ -99,8 +99,10 @@ module Orbf
           ]
           codes.each do |code|
             next unless dependencies.include?(code)
+
             keys = if code.end_with?("_quarterly")
-                     [[hash[:id], PeriodIterator.periods(period, "quarterly").first, activity_state.ext_id]]
+                     quarter = PeriodIterator.periods(period, "quarterly").first
+                     [[hash[:id], quarter, activity_state.ext_id]]
                    else
                      build_keys_with_yearly([hash[:id], period, activity_state.ext_id])
                    end

--- a/lib/orbf/rules_engine/builders/activity_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/activity_variables_builder.rb
@@ -93,11 +93,20 @@ module Orbf
 
       def parent_values(activity_state, period, dependencies)
         parents_with_level.each do |hash|
-          code = "#{activity_state.state}_level_#{hash[:level]}"
-          next unless dependencies.include?(code)
-
-          hash_value = lookup_value(build_keys_with_yearly([hash[:id], period, activity_state.ext_id]))
-          yield(hash[:id], code, hash_value)
+          codes = [
+            "#{activity_state.state}_level_#{hash[:level]}",
+            "#{activity_state.state}_level_#{hash[:level]}_quarterly"
+          ]
+          codes.each do |code|
+            next unless dependencies.include?(code)
+            keys = if code.end_with?("_quarterly")
+                     [[hash[:id], PeriodIterator.periods(period, "quarterly").first, activity_state.ext_id]]
+                   else
+                     build_keys_with_yearly([hash[:id], period, activity_state.ext_id])
+                   end
+            hash_value = lookup_value(keys)
+            yield(hash[:id], code, hash_value)
+          end
         end
       end
 

--- a/lib/orbf/rules_engine/builders/substitution_builder.rb
+++ b/lib/orbf/rules_engine/builders/substitution_builder.rb
@@ -98,13 +98,18 @@ module Orbf
 
         package.states.each do |state|
           LEVELS_RANGES.each do |level_index|
-            state_level = state + "_level_#{level_index}"
-            next unless used_in_expression?(state_level)
+            state_levels = [
+              state + "_level_#{level_index}",
+              state + "_level_#{level_index}_quarterly"
+            ]
+            state_levels.each do |state_level|
+              next unless used_in_expression?(state_level)
 
-            result[state_level] = suffix_activity_pattern(
-              package.code, activity_code, state_level,
-              "orgunit_parent_level#{level_index}_id".to_sym
-            )
+              result[state_level] = suffix_activity_pattern(
+                package.code, activity_code, state_level,
+                "orgunit_parent_level#{level_index}_id".to_sym
+              )
+            end
           end
         end
       end

--- a/lib/orbf/rules_engine/builders/substitution_builder.rb
+++ b/lib/orbf/rules_engine/builders/substitution_builder.rb
@@ -99,8 +99,8 @@ module Orbf
         package.states.each do |state|
           LEVELS_RANGES.each do |level_index|
             state_levels = [
-              state + "_level_#{level_index}",
-              state + "_level_#{level_index}_quarterly"
+              "#{state}_level_#{level_index}",
+              "#{state}_level_#{level_index}_quarterly"
             ]
             state_levels.each do |state_level|
               next unless used_in_expression?(state_level)

--- a/spec/lib/orbf/rules_engine/builders/activity_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/activity_variables_builder_spec.rb
@@ -417,6 +417,95 @@ RSpec.describe Orbf::RulesEngine::ActivityVariablesBuilder do
     end
   end
 
+
+  context "parent case with frequency" do
+    let(:activities) do
+      [
+        Orbf::RulesEngine::Activity.with(
+          name:            "act1",
+          activity_code:   "act1",
+          activity_states: [
+            Orbf::RulesEngine::ActivityState.new_data_element(
+              state:  :cap,
+              ext_id: "dhis2_act1_cap",
+              name:   "act1_target"
+            )
+          ]
+        )
+      ]
+    end
+
+    let(:package) do
+      Orbf::RulesEngine::Package.new(
+        code:       :facility,
+        kind:       :single,
+        frequency:  :quarterly,
+        activities: activities,
+        rules:      [
+          Orbf::RulesEngine::Rule.new(
+            kind:     :activity,
+            formulas: [
+              Orbf::RulesEngine::Formula.new("allowed", "cap_level_2_quarterly", "")
+            ]
+          )
+        ]
+      )
+    end
+
+    let(:dhis2_values) do
+      [
+        { "dataElement" => "dhis2_act1_cap", "categoryOptionCombo" => "default", "value" => "33", "period" => "2016Q1", "orgUnit" => "country_id", "comment" => "" },
+        { "dataElement" => "dhis2_act1_cap", "categoryOptionCombo" => "default", "value" => "12", "period" => "2016Q1", "orgUnit" => "county_id",  "comment" => "" }
+      ]
+    end
+
+    let(:expected_vars) do
+      [
+        Orbf::RulesEngine::Variable.with(
+          period:         "2016",
+          key:            "facility_act1_cap_for_1_and_2016",
+          expression:     "0",
+          state:          "cap",
+          activity_code:  "act1",
+          type:           "activity",
+          orgunit_ext_id: "1",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        ), Orbf::RulesEngine::Variable.with(
+          period:         "2016",
+          key:            "facility_act1_cap_for_2_and_2016",
+          expression:     "0",
+          state:          "cap",
+          activity_code:  "act1",
+          type:           "activity",
+          orgunit_ext_id: "2",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        ),
+        Orbf::RulesEngine::Variable.with(
+          period:         "2016",
+          key:            "facility_act1_cap_level_2_quarterly_for_county_id_and_2016",
+          expression:     "12",
+          state:          "cap_level_2_quarterly",
+          activity_code:  "act1",
+          type:           "activity",
+          orgunit_ext_id: "county_id",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        )
+      ]
+    end
+
+    it "registers activity_variables" do
+      result = described_class.new(package, orgunits, dhis2_values).convert("2016")
+      expect(result).to eq_vars(expected_vars)
+    end
+  end
+
+
   context "zone main orgunit case" do
     let(:activities) do
       [


### PR DESCRIPTION
instead of magically looking up for quarterly values (as done for yearly, financialYearly)
add more explicit support to lookup the state defined at parent level with quarterly dataset

this introduces less variables compared to the magical option and make it more evident that we are backward compatible (not mistakenly use a quarterly value that was unused before this change)