### PR TITLE
Support Exclusive mode for window_values

### DIFF
--- a/lib/orbf/rules_engine/builders/spans/spans.rb
+++ b/lib/orbf/rules_engine/builders/spans/spans.rb
@@ -129,7 +129,7 @@ module Orbf
           elsif modifier.nil?
             0
           else
-            raise "not supported exclusive mode : #{name}"
+            raise "Sorry unsupported modifier mode : #{name}"
           end
         end
 
@@ -149,7 +149,7 @@ module Orbf
             offset = (Integer(offset) - 1).months * 3
             offset_end = exclusive_offset.months * 3
           else
-            raise "Nope '#{unit}' not supported only months and quarters in #{name}"
+            raise "Sorry '#{unit}' is not supported only months and quarters in #{name}"
           end
 
           period_start = PeriodConverter.as_date_range(invoicing_period).first

--- a/lib/orbf/rules_engine/builders/spans/spans.rb
+++ b/lib/orbf/rules_engine/builders/spans/spans.rb
@@ -85,10 +85,9 @@ module Orbf
         end
 
         def periods(invoicing_period, name)
-
           quarter = PeriodIterator.periods(invoicing_period, "quarterly").first
 
-          frequencies(name,QUARTER_FREQUENCIES).each_with_object([]) do |frequency, arr|
+          frequencies(name, QUARTER_FREQUENCIES).each_with_object([]) do |frequency, arr|
             arr.push(*PeriodIterator.periods(quarter, frequency))
           end
         end
@@ -115,8 +114,7 @@ module Orbf
       end
 
       class SlidingWindow < Span
-        REGEX = /_last_(\d+)_(\w+)_window_values/
-
+        REGEX = /_last_(\d+)_([a-z]+)_?([a-z]+)?_window_values/.freeze
         def suffix
           "window"
         end
@@ -125,37 +123,44 @@ module Orbf
           name.gsub(REGEX, "")
         end
 
-        # last_6_months => 6
-        def time_offset(name)
-          name.match(REGEX)[1]
-        end
-
-        def time_unit(name)
-          name.match(REGEX)[2]
+        def exlusive_offset_for(exclusive, name)
+          if exclusive == "exclusive"
+            1
+          elsif exclusive.nil?
+            0
+          else
+            raise "not supported exclusive mode : #{name}"
+          end
         end
 
         def periods(invoicing_period, name)
-          offset = time_offset(name)
-          unit = time_unit(name)
+          matches = name.match(REGEX)
+
+          offset = matches[1]
+          unit = matches[2]
+          exlusive_offset = exlusive_offset_for(matches[3], name)
+
           if unit == "months"
             unit = "monthly"
             offset = (Integer(offset) - 1).months
+            offset_end = exlusive_offset.months
           elsif unit == "quarters"
             unit = "quarterly"
             offset = (Integer(offset) - 1).months * 3
+            offset_end = exlusive_offset.months * 3
           else
-            raise "Nope"
+            raise "Nope '#{unit}' not supported only months and quarters in #{name}"
           end
 
           period_start = PeriodConverter.as_date_range(invoicing_period).first
-          previous_range = (period_start - offset)..period_start
+          previous_range = (period_start - offset - offset_end)..(period_start - offset_end)
           result = PeriodIterator.extract_periods(previous_range, unit)
           result
         end
 
-        def frequencies(name, frequencies = FREQUENCIES)
+        def frequencies(name, _frequencies = FREQUENCIES)
           if name =~ REGEX
-            ['something']
+            ["something"]
           else
             []
           end

--- a/lib/orbf/rules_engine/builders/spans/spans.rb
+++ b/lib/orbf/rules_engine/builders/spans/spans.rb
@@ -123,10 +123,10 @@ module Orbf
           name.gsub(REGEX, "")
         end
 
-        def exlusive_offset_for(exclusive, name)
-          if exclusive == "exclusive"
+        def exclusive_offset_for(modifier, name)
+          if modifier == "exclusive"
             1
-          elsif exclusive.nil?
+          elsif modifier.nil?
             0
           else
             raise "not supported exclusive mode : #{name}"
@@ -138,16 +138,16 @@ module Orbf
 
           offset = matches[1]
           unit = matches[2]
-          exlusive_offset = exlusive_offset_for(matches[3], name)
+          exclusive_offset = exclusive_offset_for(matches[3], name)
 
           if unit == "months"
             unit = "monthly"
             offset = (Integer(offset) - 1).months
-            offset_end = exlusive_offset.months
+            offset_end = exclusive_offset.months
           elsif unit == "quarters"
             unit = "quarterly"
             offset = (Integer(offset) - 1).months * 3
-            offset_end = exlusive_offset.months * 3
+            offset_end = exclusive_offset.months * 3
           else
             raise "Nope '#{unit}' not supported only months and quarters in #{name}"
           end

--- a/spec/lib/orbf/rules_engine/builders/spans/spans_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/spans/spans_spec.rb
@@ -184,5 +184,17 @@ RSpec.describe "spans" do
         )
       end
     end
+
+    it "should fail fast on invalid modifier" do
+      expect { span.periods("2016Q1", "#{name}_last_3_months_unknown_window_values") }.to(
+        raise_error("Sorry unsupported modifier mode : sample_matching_last_3_months_unknown_window_values")
+      )
+    end
+
+    it "should fail fast on invalid period unit" do
+      expect { span.periods("2016Q1", "#{name}_last_3_weeks_exclusive_window_values") }.to(
+        raise_error("Sorry 'weeks' is not supported only months and quarters in sample_matching_last_3_weeks_exclusive_window_values")
+      )
+    end
   end
 end

--- a/spec/lib/orbf/rules_engine/builders/spans/spans_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/spans/spans_spec.rb
@@ -168,10 +168,21 @@ RSpec.describe "spans" do
       )
     end
 
-    it "" do
-      expect(span.periods("2016Q1", "#{name}_last_2_quarters_window_values")).to eq(
-        %w[2015Q4 2016Q1]
-      )
+    [
+      ["last_2_quarters", %w[2015Q4 2016Q1]],
+      ["last_2_quarters_exclusive", %w[2015Q3 2015Q4]],
+      ["last_1_quarters", %w[2016Q1]],
+      ["last_1_quarters_exclusive", %w[2015Q4]],
+      ["last_3_quarters_exclusive", %w[2015Q2 2015Q3 2015Q4]],
+      ["last_3_months", %w[201511 201512 201601]],
+      ["last_2_months_exclusive", %w[201511 201512]]
+    ].each do |suffix, expected|
+
+      it "#{suffix}_window_values for 2016Q1 should return #{expected}" do
+        expect(span.periods("2016Q1", "#{name}_#{suffix}_window_values")).to eq(
+          expected
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
currently orbf2 support
-   `%{claimed_last_x_quarters_window_values}` and
-   `%{claimed_last_x_months_window_values}`
for both the "current" quarter or month is included in the range. 

but we'd like to be able to "exclude" the current month and quarter, 
the `_months_window_values` is already in use so to avoid breaking projects using it,
we add support for
   - `%{claimed_last_x_quarters_exclusive_window_values}`
   - `%{claimed_last_x_months_exclusive_window_values}`
this would avoid creating "cycle" inadvertently.
