### PR TITLE
Travis bundler issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: ruby
 cache: bundler
 rvm:
 - 2.5.1
-before_install: gem install bundler -v 2.0.2
+before_install:
+  - gem uninstall -i /home/travis/.rvm/gems/ruby-2.5.1@global bundler -x
+  - gem install bundler -v 2.0.2
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
   > ./cc-test-reporter


### PR DESCRIPTION
So while we already tackled this by explicitly specifying which bundler version to use, see .travis.yml

      gem install bundler -v 2.0.2

In newer builds this no longer passed, because when travis called bundler again it would take a more recent version of bundler and it would complain:

      Bundler could not find compatible versions for gem "bundler":
        In Gemfile:
          bundler (~> 2.0.2)

        Current Bundler version:
          bundler (2.1.4)
      This Gemfile requires a different version of Bundler.
      Perhaps you need to update Bundler by running `gem install bundler`?

See: https://travis-ci.org/BLSQ/orbf-rules_engine/builds/634282879

So, this time we first uninstall bundler, and then install bundler. This seems to appease the bundler gods and the builds start building again.

I don't like that we have to hardcode even more things into the Travis CI script. But as long as we don't change ruby versions, this will continue to keep working.