### PR TITLE
Reject NaN from analytics

### DIFF
--- a/lib/orbf/rules_engine/fetch_data/fetch_data_analytics.rb
+++ b/lib/orbf/rules_engine/fetch_data/fetch_data_analytics.rb
@@ -26,8 +26,9 @@ module Orbf
       attr_reader :dhis2_connection, :package_arguments
 
       def map_to_data_values(analytics_response)
-        analytics_response["rows"].map do |v|
-          {
+        analytics_response["rows"].each_with_object([]) do |v, array|
+          next if v[3] == "NaN"
+          array.push(
             "dataElement"          => data_element_mappings[v[0]] || v[0],
             "period"               => v[2],
             "orgUnit"              => v[1],
@@ -35,7 +36,7 @@ module Orbf
             "attributeOptionCombo" => "default",
             "value"                => v[3],
             "origin"               => "analytics"
-          }
+          )
         end
       end
 

--- a/spec/lib/orbf/rules_engine/fetch_data/fetch_data_analytics_spec.rb
+++ b/spec/lib/orbf/rules_engine/fetch_data/fetch_data_analytics_spec.rb
@@ -104,7 +104,8 @@ RSpec.describe Orbf::RulesEngine::FetchDataAnalytics do
               .to_return(status: 200, body: JSON.pretty_generate(
                 "rows" => [
                   ["dhis2_de_1", orgunit_1.ext_id, "201601", "1.4"],
-                  ["dhis2_de_1.coc_1", orgunit_1.ext_id, "201601", "3.2"]
+                  ["dhis2_de_1.coc_1", orgunit_1.ext_id, "201601", "3.2"],
+                  ["dhis2_de_1.coc_2", orgunit_1.ext_id, "201601", "NaN"]
                 ]
               ), headers: {})
 


### PR DESCRIPTION
Don't know if it's the correct way to handle it but ...
The analytics call might return "NaN" as value

```json
...
"rows":[
     ["tMLFyuggLmB","a3ZVzKcIlMN","2019Q4","NaN"],
]
...
```
In the current project, handling it as 0/missing is fine.
The ideal solution would be to move these calculations in hesabu and not using the analytics.

The problem with NaN it gets down to the solver and hesabu search a parameter NaN. There is no way to catch it to prevent blocking all the calculations. So I think this fix is perhaps the less bad thing todo.