### PR TITLE
Add support for category option combo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 - 2.5.1
 before_install:
   - gem uninstall -i /home/travis/.rvm/gems/ruby-2.5.1@global bundler -x
-  - gem install bundler -v 2.0.2
+  - gem install bundler -v 2.1.4
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
   > ./cc-test-reporter

--- a/bin/console
+++ b/bin/console
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require "bundler"
 require "bundler/setup"
 require "orbf/rules_engine"
 

--- a/lib/orbf/rules_engine/builders/alias_post_processor.rb
+++ b/lib/orbf/rules_engine/builders/alias_post_processor.rb
@@ -3,13 +3,14 @@
 module Orbf
   module RulesEngine
     class AliasPostProcessor
-      def initialize(variables)
+      def initialize(variables, default_category_option_combo_ext_id)
         @variables = variables
+        @default_category_option_combo_ext_id = default_category_option_combo_ext_id || "default"
       end
 
       def call
-        hash_in = index_variables :dhis2_in_data_element
-        hash_out = index_variables :dhis2_data_element
+        hash_in = index_variables(:dhis2_in_data_element)
+        hash_out = index_variables(:dhis2_data_element, :dhis2_coc)
         aliases = []
         hash_in.each do |key, in_vals|
           out_vals = hash_out[key]
@@ -38,13 +39,17 @@ module Orbf
 
       attr_reader :variables
 
-      def index_variables(dhis2_element_meth)
+      def index_variables(dhis2_element_meth, coc_meth = nil)
         variables.each_with_object({}) do |variable, hash|
-          data_element = variable.public_send dhis2_element_meth
+          data_element = variable.public_send(dhis2_element_meth)
+          coc = coc_meth ? variable.public_send(coc_meth) : nil
           next unless data_element
+          components = data_element.split('.')
           key = { period:       variable.dhis2_period,
                   orgunit:      variable.orgunit_ext_id,
-                  data_element: data_element }
+                  data_element: components[0],
+                  coc: components[1] || coc || @default_category_option_combo_ext_id
+              }
           hash[key] ||= []
           hash[key].push variable
         end

--- a/lib/orbf/rules_engine/builders/solver_factory.rb
+++ b/lib/orbf/rules_engine/builders/solver_factory.rb
@@ -10,6 +10,7 @@ module Orbf
         @package_vars = package_vars
         @package_arguments = package_arguments
         raise PACKAGE_TYPE_ERROR unless package_arguments.is_a?(Hash)
+
         @package_builders = package_builders || default_package_builders
       end
 
@@ -25,7 +26,7 @@ module Orbf
       private
 
       def register_aliases(solver)
-        alias_post_processor = AliasPostProcessor.new solver.variables
+        alias_post_processor = AliasPostProcessor.new(solver.variables, project.default_category_option_combo_ext_id)
         solver.register_variables(alias_post_processor.call)
       end
 
@@ -33,6 +34,7 @@ module Orbf
         project.packages.each do |package|
           package_argument = package_arguments[package]
           next unless package_argument
+
           register_package(solver, package, package_argument)
         end
       end

--- a/lib/orbf/rules_engine/data/activity_state.rb
+++ b/lib/orbf/rules_engine/data/activity_state.rb
@@ -42,7 +42,7 @@ module Orbf
         def self.assert_valid_origin(activity_state_origin, instance)
           return if ORIGINS.include?(activity_state_origin)
 
-          raise "Invalid activity state origin '#{activity_state_kind}' only supports #{ORIGINS}: #{instance.debug_info}"
+          raise "Invalid activity state origin '#{activity_state_origin}' only supports #{ORIGINS}: #{instance.debug_info}"
         end
       end
 
@@ -92,7 +92,7 @@ module Orbf
         after_init
       end
 
-      attr_reader :state, :ext_id, :name, :kind, :formula, :category_combo_ext_id 
+      attr_reader :state, :ext_id, :name, :kind, :formula, :category_combo_ext_id
 
       def origin
         @origin || "dataValueSets"

--- a/lib/orbf/rules_engine/data/formula.rb
+++ b/lib/orbf/rules_engine/data/formula.rb
@@ -32,16 +32,19 @@ module Orbf
         dependencies + values_dependencies
       end
 
-      def dhis2_mapping(activity_code = nil)
-        return activity_mappings[activity_code] if activity_mappings
-        return single_mapping if single_mapping
+      def dhis2_mapping_de(activity_code = nil)
+        (dhis2_mapping(activity_code) || "").split(".")[0]
+      end
+
+      def dhis2_mapping_coc(activity_code = nil)
+        (dhis2_mapping(activity_code) || "").split(".")[1]
       end
 
       def data_elements_ids
         if single_mapping
-          [single_mapping]
+          [single_mapping.split(".")[0]]
         elsif activity_mappings
-          activity_mappings.values
+          activity_mappings.values.map { |v| v.split(".")[0] }
         else
           []
         end
@@ -50,6 +53,11 @@ module Orbf
       private
 
       attr_reader :single_mapping, :activity_mappings
+
+      def dhis2_mapping(activity_code = nil)
+        return activity_mappings[activity_code] if activity_mappings
+        return single_mapping if single_mapping
+      end
 
       def mocked_values
         values_dependencies.each_with_object({}) do |k, mocked_value|

--- a/lib/orbf/rules_engine/data/variable.rb
+++ b/lib/orbf/rules_engine/data/variable.rb
@@ -179,7 +179,11 @@ module Orbf
       end
 
       def dhis2_data_element
-        formula&.dhis2_mapping(activity_code)
+        formula&.dhis2_mapping_de(activity_code)
+      end
+
+      def dhis2_coc
+        formula&.dhis2_mapping_coc(activity_code)
       end
 
       def exportable_value(solution)

--- a/lib/orbf/rules_engine/printers/dhis2_values_printer.rb
+++ b/lib/orbf/rules_engine/printers/dhis2_values_printer.rb
@@ -29,9 +29,17 @@ module Orbf
       end
 
       def add_coc_and_aoc(variable, value)
-        value[:categoryOptionCombo] ||= variable.category_option_combo_ext_id if variable.category_option_combo_ext_id.present?
-        value[:categoryOptionCombo] ||= default_category_option_combo_ext_id if default_category_option_combo_ext_id.present?
-        value[:attributeOptionCombo] ||= default_attribute_option_combo_ext_id if default_attribute_option_combo_ext_id.present?
+        if variable.category_option_combo_ext_id.present?
+          value[:categoryOptionCombo] ||= variable.category_option_combo_ext_id
+        elsif variable.dhis2_coc
+          value[:categoryOptionCombo] ||= variable.dhis2_coc
+        elsif default_category_option_combo_ext_id.present?
+          value[:categoryOptionCombo] ||= default_category_option_combo_ext_id
+        end
+
+        if default_attribute_option_combo_ext_id.present?
+          value[:attributeOptionCombo] ||= default_attribute_option_combo_ext_id
+        end
         value
       end
 

--- a/orbf-rules_engine.gemspec
+++ b/orbf-rules_engine.gemspec
@@ -1,3 +1,4 @@
+# coding: utf-8
 
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
@@ -37,7 +38,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dhis2", "2.3.8"
   spec.add_dependency "descriptive_statistics"
 
-  spec.add_development_dependency "bundler", "~> 2.0.2"
+  spec.add_development_dependency "bundler", "~> 2.1.4"
   spec.add_development_dependency "ruby-prof"
   spec.add_development_dependency "byebug"
   spec.add_development_dependency "pronto"

--- a/spec/coc_spec.rb
+++ b/spec/coc_spec.rb
@@ -1,0 +1,242 @@
+RSpec.describe "allow to export nil" do
+  let(:orgunit) do
+    Orbf::RulesEngine::OrgUnit.with(
+      ext_id:        "1",
+      path:          "country_id/county_id/1",
+      name:          "African Foundation Baptist",
+      group_ext_ids: ["contracgroup1"]
+    )
+  end
+
+  let(:groupset) do
+    Orbf::RulesEngine::OrgUnitGroupset.with(
+      name:          "contracts",
+      ext_id:        "contracts_groupset_ext_id",
+      group_ext_ids: ["contracgroup1"],
+      code:          "contracts"
+    )
+  end
+
+  let(:orgunit_groups) do
+    [
+      Orbf::RulesEngine::OrgUnitGroup.with(
+        ext_id: "contracgroup1",
+        code:   "contract group 1",
+        name:   "contract group 1"
+      ),
+      Orbf::RulesEngine::OrgUnitGroup.with(
+        ext_id: "primary",
+        code:   "primary",
+        name:   "Primary"
+      ),
+      Orbf::RulesEngine::OrgUnitGroup.with(
+        ext_id: "cs",
+        code:   "cs",
+        name:   "cs"
+      )
+    ]
+  end
+
+  let(:pyramid) do
+    Orbf::RulesEngine::Pyramid.new(
+      org_units:          [orgunit],
+      org_unit_groups:    orgunit_groups,
+      org_unit_groupsets: [groupset]
+    )
+  end
+
+  let(:activity_a) do
+    Orbf::RulesEngine::Activity.with(
+      name:            "acta",
+      activity_code:   "acta",
+      activity_states: [
+        Orbf::RulesEngine::ActivityState.new_indicator(
+          state:      :stock_start,
+          ext_id:     "dhis2acta.stockstartco",
+          name:       "inlined-dhis2acta.stockstartco",
+          origin:     "dataValueSets",
+          expression: '#{dhis2acta.stockstartcoc}'
+        ),
+        Orbf::RulesEngine::ActivityState.new_indicator(
+          state:      :stock_end,
+          ext_id:     "dhis2acta.stockendcoc",
+          name:       "inlined-dhis2acta.stockendcoc",
+          origin:     "dataValueSets",
+          expression: '#{dhis2acta.stockendcoc}'
+        )
+
+      ]
+    )
+  end
+
+  let(:package_a) do
+    Orbf::RulesEngine::Package.new(
+      code:                        :quantity_a,
+      kind:                        :single,
+      frequency:                   :quarterly,
+      activities:                  [activity_a],
+      main_org_unit_group_ext_ids: ["contracgroup1"],
+      rules:                       [
+        Orbf::RulesEngine::Rule.new(
+          kind:     :activity,
+          formulas: [
+            Orbf::RulesEngine::Formula.new(
+              "consumption", "stock_start - stock_end", "",
+              activity_mappings: {
+                "acta" => "dhis2acta.consumptioncoc"
+              }
+            )
+
+          ]
+        )
+      ]
+    )
+  end
+
+  let(:activity_b) do
+    Orbf::RulesEngine::Activity.with(
+      name:            "actb",
+      activity_code:   "actb",
+      activity_states: [
+        Orbf::RulesEngine::ActivityState.new_indicator(
+          state:      :consumption,
+          ext_id:     "dhis2acta.consumptioncoc",
+          name:       "inlined-dhis2acta.consumptioncoc",
+          origin:     "dataValueSets",
+          expression: '#{dhis2acta.consumptioncoc}'
+        ),
+        Orbf::RulesEngine::ActivityState.new_indicator(
+          state:      :stock_end,
+          ext_id:     "dhis2acta.stockendcoc",
+          name:       "inlined-dhis2acta.stockendcoc",
+          origin:     "dataValueSets",
+          expression: '#{dhis2acta.stockendcoc}'
+        )
+      ]
+    )
+  end
+
+  let(:package_b) do
+    Orbf::RulesEngine::Package.new(
+      code:                        :quantity_b,
+      kind:                        :single,
+      frequency:                   :quarterly,
+      activities:                  [activity_b],
+      main_org_unit_group_ext_ids: ["contracgroup1"],
+      rules:                       [
+        Orbf::RulesEngine::Rule.new(
+          kind:     :activity,
+          formulas: [
+            Orbf::RulesEngine::Formula.new(
+              "score", "round(safe_div(consumption, stock_end) * 100,2)", "",
+              activity_mappings: {
+                "actb" => "dhis2actb.scorecoc"
+              }
+            )
+
+          ]
+        )
+      ]
+    )
+  end
+
+  let(:payment_rule) do
+    Orbf::RulesEngine::PaymentRule.new(
+      code:      "pbf_payment",
+      frequency: :quarterly,
+      packages:  [package_a, package_b],
+      rule:      Orbf::RulesEngine::Rule.new(
+        kind:     "payment",
+        formulas: [
+          Orbf::RulesEngine::Formula.new(
+            "nothing",
+            "1",
+            "",
+            single_mapping: "payment_de"
+          )
+        ]
+      )
+    )
+  end
+
+  let(:project) do
+    Orbf::RulesEngine::Project.new(
+      packages:      [
+        package_a,
+        package_b
+
+      ],
+      payment_rules: [
+        payment_rule
+      ],
+      dhis2_params:  {
+        url:      "https://admin:district@play.dhis2.org/2.28",
+        user:     "admin",
+        password: "district"
+      }
+    )
+  end
+
+  describe "when data" do
+    let(:fetch_and_solve) do
+      Orbf::RulesEngine::FetchAndSolve.new(
+        project,
+        "1",
+        "2018Q1",
+        pyramid:     pyramid,
+        mock_values: [
+          {
+            "orgUnit"             => "1",
+            "period"              => "2018Q1",
+            "dataElement"         => "dhis2acta",
+            "categoryOptionCombo" => "stockstartcoc",
+            "value"               => "8"
+          },
+          {
+            "orgUnit"             => "1",
+            "period"              => "2018Q1",
+            "dataElement"         => "dhis2acta",
+            "categoryOptionCombo" => "stockendcoc",
+            "value"               => "6"
+          }
+        ]
+      )
+    end
+
+    it "aliases package a formula output to package b activity state and export the correct value for both packages" do
+      # Package A will read from `dhis2acta` got get the `stock_start`
+      # (`stockstartcoc`) and `stock_end` (`stockendcoc`), it will then
+      # output a `comsumption` to `"dhis2acta.consumptioncoc"`.
+      #
+      # Package B will read from `dhis2acta` to get the `stock_end`
+      # (`stockendcoc`) and from the newly created
+      # `dhis2acta.consumptioncoc`
+      #
+      # So putting this all together, if `start_stock` is 8 and `stock_end`
+      # is 6, the `consumption` will be 2 and that will be stored in
+      # `dhis2acta.consumptioncoc`
+
+      fetch_and_solve.call
+
+      invoices = Orbf::RulesEngine::InvoicePrinter.new(
+        fetch_and_solve.solver.variables,
+        fetch_and_solve.solver.solution
+      ).print
+
+      invoice = invoices.first
+
+      expect(fetch_and_solve.exported_values).to eq(
+        [
+          { dataElement: "dhis2acta", orgUnit: "1", period: "2018Q1",
+              value: (8.0 - 6.0), comment: "quantity_a_acta_consumption_for_1_and_2018q1",
+               categoryOptionCombo: "consumptioncoc" },
+          { dataElement: "dhis2actb", orgUnit: "1", period: "2018Q1",
+              value: (2.0 / 6.0 * 100).round(2), comment: "quantity_b_actb_score_for_1_and_2018q1",
+              categoryOptionCombo: "scorecoc" },
+          { dataElement: "payment_de", orgUnit: "1", period: "2018Q1",
+              value: 1, comment: "pbf_payment_nothing_for_1_and_2018q1" }
+        ]
+      )
+    end
+  end
+end

--- a/spec/lib/orbf/rules_engine/data/activity_state_spec.rb
+++ b/spec/lib/orbf/rules_engine/data/activity_state_spec.rb
@@ -1,6 +1,6 @@
 RSpec.describe Orbf::RulesEngine::ActivityState do
   it "fails fast with helpful message when formula is missing" do
-    expect {
+    expect do
       Orbf::RulesEngine::ActivityState.with(
         kind:    "indicator",
         state:   "mystate",
@@ -8,7 +8,7 @@ RSpec.describe Orbf::RulesEngine::ActivityState do
         name:    "myname",
         formula: nil
       )
-    }.to raise_error("formula required for indicator : state:'mystate' ext_id:'myext_id' name:'myname' kind:'indicator' formula:'' origin:'dataValueSets'")
+    end.to raise_error("formula required for indicator : state:'mystate' ext_id:'myext_id' name:'myname' kind:'indicator' formula:'' origin:'dataValueSets'")
   end
 
   it "fails fast when incorrect kind" do
@@ -21,5 +21,18 @@ RSpec.describe Orbf::RulesEngine::ActivityState do
         formula: "formula"
       )
     end.to raise_error("Invalid activity state kind 'badbadkind' only supports [\"constant\", \"data_element\", \"indicator\"] : state:'state' ext_id:'ext_id' name:'name' kind:'badbadkind' formula:'formula' origin:'dataValueSets'")
+  end
+
+  it "fails fast when incorrect origins" do
+    expect do
+      Orbf::RulesEngine::ActivityState.with(
+        kind:    "indicator",
+        state:   "state",
+        ext_id:  "ext_id",
+        name:    "name",
+        formula: "formula",
+        origin:  "unkowndhis2api"
+      )
+    end.to raise_error("Invalid activity state origin 'unkowndhis2api' only supports [\"dataValueSets\", \"analytics\"]: state:'state' ext_id:'ext_id' name:'name' kind:'indicator' formula:'formula' origin:'unkowndhis2api'")
   end
 end

--- a/spec/lib/orbf/rules_engine/fetch_data/datasets/compute_datasets_spec.rb
+++ b/spec/lib/orbf/rules_engine/fetch_data/datasets/compute_datasets_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Orbf::RulesEngine::Datasets do
             Orbf::RulesEngine::Formula.new(
               "half_price", "price/2",
               "",
-              activity_mappings: { "act1" => "de_act1_month" }
+              activity_mappings: { "act1" => "de_act1_month.coc" }
             ),
             Orbf::RulesEngine::Formula.new(
               "half_price_quarterl", "price/2",
@@ -159,6 +159,8 @@ RSpec.describe Orbf::RulesEngine::Datasets do
         [payment_rule, "quarterly"] => Set.new(%w[de_act1_quarter de2_pack_quarter])
       }
 
+       #<Set: {"de_act1_month.coc", "de1_pack_month"}>
+       #<Set: {"de_act1_month", "de1_pack_month"}>
       expected_elements.each do |k, _v|
         expect(expected_elements[k]).to eq(data_elements[k])
       end

--- a/spec/lib/orbf/rules_engine/printers/dhis2_values_printer_spec.rb
+++ b/spec/lib/orbf/rules_engine/printers/dhis2_values_printer_spec.rb
@@ -331,6 +331,39 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
       end
     end
 
+    describe "and mapping configured with category combo" do
+      let(:data_element_id) { "dhis2_data_element_id" }
+      let(:coc_id) { "specific_coc_id"}
+      let(:variable_with_mapping) do
+        build_activity_variable(
+          activity_mappings: {
+            activity.activity_code => "#{data_element_id}.#{coc_id}"
+          },
+          frequency:         "monthly"
+        )
+      end
+
+      it "export values " do
+        result_values = described_class.new(
+          [variable_with_mapping],
+          { variable_with_mapping.key => 53 }
+        ).print
+
+        expect(result_values).to eq(
+          [
+            {
+              dataElement:          data_element_id,
+              orgUnit:              "1",
+              period:               "201603",
+              value:                53,
+              comment:              variable_with_mapping.key,
+              categoryOptionCombo:  coc_id
+            }
+          ]
+        )
+      end
+    end
+
     def expect_exported_value(variable, solution_value, expected_value, period)
       result_values = described_class.new(
         [variable],

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,4 @@
+require "bundler"
 require "bundler/setup"
 require "rspec"
 require "simplecov"


### PR DESCRIPTION
This adds support to oudput variables to a category option combo as well.

You'll need to map the formula to the category option combo (a PR for orbf2 will add this), after this the formula will be mapped to `data_element_id.coc_id`, we're splitting on the `.` so normally we're backwards compatible.