### PR TITLE
Change ValueObject initializer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,11 @@ sudo: false
 language: ruby
 cache: bundler
 rvm:
-- 2.5.1
+  - 2.5
+  - 2.6
+  - 2.7
 before_install:
-  - gem uninstall -i /home/travis/.rvm/gems/ruby-2.5.1@global bundler -x
-  - gem install bundler -v 2.1.4
+  - gem install bundler
 before_script:
 - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64
   > ./cc-test-reporter

--- a/lib/orbf/rules_engine/builders/activity_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/activity_variables_builder.rb
@@ -5,16 +5,7 @@ module Orbf
     class ActivityVariablesBuilder
       include VariablesBuilderSupport
 
-      class ValueLookup < Orbf::RulesEngine::ValueObject
-        attributes :value, :is_null
-
-        attr_reader :value, :is_null
-
-        def initialize(value:, is_null:)
-          @value = value
-          @is_null = is_null
-          freeze
-        end
+      class ValueLookup < Orbf::RulesEngine::ValueObject::Model(:value, :is_null)
       end
 
       class << self
@@ -143,14 +134,13 @@ module Orbf
                  end
 
           next unless vals
-
           looked_vals = vals.map { |val| val["value"] }.compact
 
           next if looked_vals.empty?
 
           if looked_vals.size == 1
             # preserved type of original value (avoid to string)
-            return ValueLookup.new(value: looked_vals.first, is_null: false)
+            return ValueLookup.with(value: looked_vals.first, is_null: false)
           end
 
           looked_vals = if activity_state.origin_data_value_sets?
@@ -159,9 +149,9 @@ module Orbf
                           vals.reject { |val| val["origin"] != "analytics" || val["value"].nil? }
                         end
 
-          return ValueLookup.new(value: looked_vals.map { |val| val["value"] }.join(" + "), is_null: false)
+          return ValueLookup.with(value: looked_vals.map { |val| val["value"] }.join(" + "), is_null: false)
         end
-        ValueLookup.new(value: "0", is_null: true)
+        ValueLookup.with(value: "0", is_null: true)
       end
 
       def build_keys_with_yearly(key)

--- a/lib/orbf/rules_engine/builders/calculator_factory.rb
+++ b/lib/orbf/rules_engine/builders/calculator_factory.rb
@@ -88,6 +88,13 @@ module Orbf
           calculator.add_function(:between, :logical, BETWEEN)
           calculator.add_function(:abs, :number, ->(number) { number.abs })
           calculator.add_function(:score_table, :numeric, SCORE_TABLE)
+          # Dentaku now has AVG and SUM builtin, as well as ROUNDDOWN and ROUNDUP
+          # Their behavior is slightly different.
+          #      AVG(1,3,9) => In our function: 4,333333
+          #                    In Dentaku: 4.0 (if one of the elements is a float, it does work the same)
+          #
+          # Since we're mostly using our go-hesabu library, I'm just keeping these as is and ignoring the
+          # builtin functions.
           calculator.add_function(:avg, :numeric, AVG)
           calculator.add_function(:sum, :numeric, SUM)
           calculator.add_function(:safe_div, :numeric, SAFE_DIV)

--- a/lib/orbf/rules_engine/builders/indicator_expression_parser.rb
+++ b/lib/orbf/rules_engine/builders/indicator_expression_parser.rb
@@ -2,15 +2,7 @@
 
 module Orbf
   module RulesEngine
-    class IndicatorExpression < Orbf::RulesEngine::ValueObject
-      attributes :expression, :data_element, :category_combo
-      attr_reader :expression, :data_element, :category_combo
-      def initialize(expression: nil, data_element: nil, category_combo: nil)
-        @expression = expression
-        @data_element = data_element
-        @category_combo = category_combo
-        freeze
-      end
+    class IndicatorExpression < Orbf::RulesEngine::ValueObject::Model(:expression, :data_element, :category_combo)
     end
 
     class UnsupportedFormulaException < StandardError
@@ -45,7 +37,7 @@ module Orbf
         def to_indicator_expression(expression)
           data_element_category =  expression.sub('#{', "").sub("}", "")
           data_element, category = data_element_category.split(".").map(&:strip)
-          IndicatorExpression.new(
+          IndicatorExpression.with(
             expression:     '#{' + expression.strip + '}',
             data_element:   data_element,
             category_combo: category

--- a/lib/orbf/rules_engine/data/activity.rb
+++ b/lib/orbf/rules_engine/data/activity.rb
@@ -2,18 +2,9 @@
 
 module Orbf
   module RulesEngine
-    class Activity < RulesEngine::ValueObject
-      attributes :name, :activity_code, :activity_states
+    class Activity < RulesEngine::ValueObject::Model(:name, :activity_code, :activity_states)
 
-      attr_reader :name, :activity_code, :activity_states
-
-      def initialize(name:, activity_code:, activity_states:)
-        @name = name
-        @activity_code = activity_code
-        @activity_states = activity_states
-      end
-
-      def states 
+      def states
         @states ||= activity_states.map(&:state).freeze
       end
     end

--- a/lib/orbf/rules_engine/data/activity_state.rb
+++ b/lib/orbf/rules_engine/data/activity_state.rb
@@ -1,7 +1,6 @@
 module Orbf
   module RulesEngine
-    class ActivityState < Orbf::RulesEngine::ValueObject
-      attributes :state, :ext_id, :name, :kind, :formula, :origin, :category_combo_ext_id
+    class ActivityState < Orbf::RulesEngine::ValueObject::Model(:state, :ext_id, :name, :kind, :formula, :origin, :category_combo_ext_id)
 
       module Kinds
         KIND_CONSTANT = "constant".freeze
@@ -80,22 +79,8 @@ module Orbf
         )
       end
 
-      def initialize(state: nil, ext_id: nil, name: nil, kind: nil, formula: nil, origin: nil, category_combo_ext_id: nil)
-        @state = state
-        @ext_id = ext_id
-        @name = name
-        @kind = kind
-        @formula = formula
-        @origin =  origin
-        @category_combo_ext_id = category_combo_ext_id
-
-        after_init
-      end
-
-      attr_reader :state, :ext_id, :name, :kind, :formula, :category_combo_ext_id
-
       def origin
-        @origin || "dataValueSets"
+        @values[:origin] || "dataValueSets"
       end
 
       def constant?
@@ -123,9 +108,9 @@ module Orbf
       end
 
       def after_init
-        raise "State is mandatory #{debug_info}" unless @state
+        raise "State is mandatory #{debug_info}" unless state
 
-        @state = state.to_s
+        @values[:state] = state.to_s
         Kinds.assert_valid_kind_and_formula(kind, formula,self )
         Origins.assert_valid_origin(origin, self)
       end

--- a/lib/orbf/rules_engine/data/dataset_info.rb
+++ b/lib/orbf/rules_engine/data/dataset_info.rb
@@ -1,8 +1,7 @@
 
 module Orbf
   module RulesEngine
-    class DatasetInfo < RulesEngine::ValueObject
-      attributes :payment_rule_code, :frequency, :data_elements, :orgunits
+    class DatasetInfo < RulesEngine::ValueObject::Model(:payment_rule_code, :frequency, :data_elements, :orgunits)
     end
   end
 end

--- a/lib/orbf/rules_engine/data/invoice.rb
+++ b/lib/orbf/rules_engine/data/invoice.rb
@@ -3,7 +3,7 @@ module Orbf
     class ActivityItem < Orbf::RulesEngine::ValueObject::Model(:activity, :solution, :problem, :substitued, :variables)
 
       def after_init
-        @indexed_variables = (variables || {}).index_by { |v| [v.state, v.activity_code] }
+        @indexed_variables = variables.index_by { |v| [v.state, v.activity_code] }
         freeze
       end
 

--- a/lib/orbf/rules_engine/data/invoice.rb
+++ b/lib/orbf/rules_engine/data/invoice.rb
@@ -1,16 +1,9 @@
 module Orbf
   module RulesEngine
-    class ActivityItem < Orbf::RulesEngine::ValueObject
-      attributes :activity, :solution, :problem, :substitued, :variables
-      attr_reader :activity, :solution, :problem, :substitued, :variables
+    class ActivityItem < Orbf::RulesEngine::ValueObject::Model(:activity, :solution, :problem, :substitued, :variables)
 
-      def initialize(activity: nil, solution: nil, problem: nil, substitued: nil, variables: nil)
-        @activity = activity
-        @solution = solution
-        @problem = problem
-        @substitued = substitued
-        @variables = variables
-        @indexed_variables = variables.index_by { |v| [v.state, v.activity_code] }
+      def after_init
+        @indexed_variables = (variables || {}).index_by { |v| [v.state, v.activity_code] }
         freeze
       end
 
@@ -40,20 +33,9 @@ module Orbf
       end
     end
 
-    class TotalItem < Orbf::RulesEngine::ValueObject
-      attributes :formula, :explanations, :value, :not_exported
-      attr_reader :formula, :explanations, :value, :not_exported
-
-      def initialize(formula: nil, explanations: nil, value: nil, not_exported:)
-        @formula = formula
-        @explanations = explanations
-        @value = value
-        @not_exported = not_exported
-        freeze
-      end
-
+    class TotalItem < Orbf::RulesEngine::ValueObject::Model(:formula, :explanations, :value, :not_exported)
       def not_exported?
-        @not_exported
+        not_exported
       end
 
       def inspect
@@ -61,8 +43,7 @@ module Orbf
       end
     end
 
-    class Invoice < Orbf::RulesEngine::ValueObject
-      attributes :kind, :period, :orgunit_ext_id, :package, :payment_rule, :activity_items, :total_items
+    class Invoice < Orbf::RulesEngine::ValueObject::Model(:kind, :period, :orgunit_ext_id, :package, :payment_rule, :activity_items, :total_items)
 
       def code
         package&.code || payment_rule&.code

--- a/lib/orbf/rules_engine/data/org_unit.rb
+++ b/lib/orbf/rules_engine/data/org_unit.rb
@@ -2,16 +2,9 @@
 
 module Orbf
   module RulesEngine
-    class OrgUnit < Orbf::RulesEngine::ValueObject
-      attributes :ext_id, :name, :path, :group_ext_ids
-
-      attr_reader :ext_id, :name, :path, :group_ext_ids, :parent_ext_ids
-
-      def initialize(ext_id:, name:, path:, group_ext_ids:)
-        @ext_id = ext_id
-        @name = name
-        @path = path
-        @group_ext_ids = group_ext_ids || []
+    class OrgUnit < Orbf::RulesEngine::ValueObject::Model(:ext_id, :name, :path, :group_ext_ids)
+      def group_ext_ids
+        @values.fetch(:group_ext_ids, [])
       end
 
       def parent_ext_ids

--- a/lib/orbf/rules_engine/data/org_unit_group.rb
+++ b/lib/orbf/rules_engine/data/org_unit_group.rb
@@ -2,14 +2,7 @@
 
 module Orbf
   module RulesEngine
-    class OrgUnitGroup < Orbf::RulesEngine::ValueObject
-      attributes :ext_id, :name, :code
-      attr_reader :ext_id, :name, :code
-      def initialize(ext_id:, name:, code:)
-        @ext_id = ext_id
-        @name = name
-        @code = code
-      end
+    class OrgUnitGroup < Orbf::RulesEngine::ValueObject::Model(:ext_id, :name, :code)
     end
   end
 end

--- a/lib/orbf/rules_engine/data/org_unit_groupset.rb
+++ b/lib/orbf/rules_engine/data/org_unit_groupset.rb
@@ -2,16 +2,7 @@
 
 module Orbf
   module RulesEngine
-    class OrgUnitGroupset < Orbf::RulesEngine::ValueObject
-      attributes :ext_id, :name, :group_ext_ids, :code
-      attr_reader :ext_id, :name, :group_ext_ids, :code
-      def initialize(ext_id:, name:, group_ext_ids:, code:)
-        @ext_id = ext_id
-        @name = name
-        @group_ext_ids = group_ext_ids
-        @code = code
-        freeze
-      end
+    class OrgUnitGroupset < Orbf::RulesEngine::ValueObject::Model(:ext_id, :name, :group_ext_ids, :code)
     end
   end
 end

--- a/lib/orbf/rules_engine/data/org_unit_with_facts.rb
+++ b/lib/orbf/rules_engine/data/org_unit_with_facts.rb
@@ -3,27 +3,17 @@
 module Orbf
   module RulesEngine
     # behave like OrgUnit but holds extra facts
-    class OrgUnitWithFacts < Orbf::RulesEngine::ValueObject
-      attributes :orgunit, :facts
-
-      attr_reader :orgunit, :facts
-
-      def initialize(orgunit:, facts:)
-        @orgunit = orgunit
-        @facts = facts
-        freeze
-      end
-
+    class OrgUnitWithFacts < Orbf::RulesEngine::ValueObject::Model(:orgunit, :facts)
       def eql?(other)
         self.class == other.class && ext_id == other.ext_id
       end
 
       def ext_id
-        @orgunit.ext_id
+        orgunit.ext_id
       end
 
       def parent_ext_ids
-        @orgunit.parent_ext_ids
+        orgunit.parent_ext_ids
       end
 
       delegate :hash, to: :ext_id

--- a/lib/orbf/rules_engine/data/package_arguments.rb
+++ b/lib/orbf/rules_engine/data/package_arguments.rb
@@ -1,16 +1,6 @@
 module Orbf
   module RulesEngine
-    class PackageArguments < Orbf::RulesEngine::ValueObject
-      attributes :periods, :orgunits, :datasets_ext_ids, :package
-      attr_reader :periods, :orgunits, :datasets_ext_ids, :package
-
-      def initialize(periods:, orgunits:, datasets_ext_ids:, package:)
-        @periods = periods
-        @orgunits = orgunits
-        @datasets_ext_ids = datasets_ext_ids
-        @package = package
-        freeze
-      end
+    class PackageArguments < Orbf::RulesEngine::ValueObject::Model(:periods, :orgunits, :datasets_ext_ids, :package)
     end
   end
 end

--- a/lib/orbf/rules_engine/data/variable.rb
+++ b/lib/orbf/rules_engine/data/variable.rb
@@ -2,7 +2,12 @@
 
 module Orbf
   module RulesEngine
-    class Variable < Orbf::RulesEngine::ValueObject
+    class Variable < Orbf::RulesEngine::ValueObject::Model(
+            :key, :period, :expression, :type, :state,
+            :activity_code, :orgunit_ext_id, :formula, :package, :payment_rule,
+            :exportable_variable_key, :category_option_combo_ext_id,
+            :formula, :payment_rule)
+
       class << self
         def new_activity_decision_table(params)
           Variable.with(
@@ -132,33 +137,6 @@ module Orbf
         ].freeze
       end
 
-      ATTRIBUTES = %i[key period expression type state activity_code 
-        orgunit_ext_id formula package payment_rule exportable_variable_key
-        category_option_combo_ext_id
-      ].freeze
-
-      attributes(*ATTRIBUTES)
-      attr_reader(*ATTRIBUTES)
-      attr_reader :dhis2_period
-
-      def initialize(key: nil, period: nil, expression: nil, type: nil, state: nil,
-                     activity_code: nil, orgunit_ext_id: nil, formula: nil, package: nil, payment_rule: nil,
-                     exportable_variable_key: nil, category_option_combo_ext_id: nil)
-        @key = key
-        @period = period
-        @expression = expression
-        @type = type
-        @state = state
-        @activity_code = activity_code
-        @orgunit_ext_id = orgunit_ext_id
-        @formula = formula
-        @package = package
-        @payment_rule = payment_rule
-        @exportable_variable_key = exportable_variable_key
-        @category_option_combo_ext_id = category_option_combo_ext_id
-        after_init
-      end
-
       def exportable?
         !!(orgunit_ext_id && dhis2_data_element)
       end
@@ -170,11 +148,11 @@ module Orbf
         return nil unless activity
 
         # this is to minimize allocations
+        state = @values[:state].to_s
         special_state = state.end_with?("_zone_main_orgunit", "_raw")
         activity_state = activity.activity_states.detect do |as|
           as.state == state || (special_state && (as.state + "_zone_main_orgunit" == state || as.state + "_raw" == state))
         end
-
         activity_state&.ext_id
       end
 
@@ -209,32 +187,23 @@ module Orbf
         type == Types::PAYMENT_RULE
       end
 
+      def dhis2_period
+        @dhis2_period ||= if formula&.frequency
+                          Orbf::RulesEngine::PeriodIterator.periods(period, formula.frequency).last
+                        else
+                          period
+                        end
+      end
+
       protected
 
       def values
-        @values ||= {
-          key:            @key,
-          period:         @period,
-          expression:     @expression,
-          type:           @type,
-          state:          @state,
-          activity_code:  @activity_code,
-          orgunit_ext_id: @orgunit_ext_id,
-          formula:        @formula,
-          package:        @package,
-          payment_rule:   @payment_rule
-        }
+        @values.slice(:key, :period, :expression, :type, :state, :activity_code, :orgunit_ext_id, :formula, :package, :payment_rule)
       end
 
       private
 
       def after_init
-        @dhis2_period = if formula&.frequency
-                          Orbf::RulesEngine::PeriodIterator.periods(period, formula.frequency).last
-                        else
-                          period
-                        end
-
         raise "Variable type '#{type}' must be one of #{Types::TYPES}" unless Types::TYPES.include?(type.to_s)
       end
     end

--- a/lib/orbf/rules_engine/fetch_data/datasets/compute_datasets.rb
+++ b/lib/orbf/rules_engine/fetch_data/datasets/compute_datasets.rb
@@ -27,7 +27,7 @@ module Orbf
             next unless orgunits_per_package[package.code]
             set.merge(orgunits_per_package[package.code])
           end
-          Orbf::RulesEngine::DatasetInfo.new(
+          Orbf::RulesEngine::DatasetInfo.with(
             payment_rule_code: payment_rule.code,
             frequency:         frequency,
             data_elements:     data_elements.to_a,

--- a/lib/orbf/rules_engine/fetch_data/pyramid_factory.rb
+++ b/lib/orbf/rules_engine/fetch_data/pyramid_factory.rb
@@ -21,7 +21,7 @@ module Orbf
         private
 
         def to_org_unit(ou)
-          Orbf::RulesEngine::OrgUnit.new(
+          Orbf::RulesEngine::OrgUnit.with(
             ext_id:        ou["id"],
             name:          display_name(ou),
             path:          ou["path"],
@@ -30,7 +30,7 @@ module Orbf
         end
 
         def to_org_unit_group(group)
-          Orbf::RulesEngine::OrgUnitGroup.new(
+          Orbf::RulesEngine::OrgUnitGroup.with(
             ext_id: group["id"],
             name:   display_name(group),
             code:   to_code(group)
@@ -38,7 +38,7 @@ module Orbf
         end
 
         def to_org_unit_group_set(gs)
-          Orbf::RulesEngine::OrgUnitGroupset.new(
+          Orbf::RulesEngine::OrgUnitGroupset.with(
             ext_id:        gs["id"],
             name:          display_name(gs),
             code:          to_code(gs),

--- a/lib/orbf/rules_engine/fetch_data/resolve_arguments.rb
+++ b/lib/orbf/rules_engine/fetch_data/resolve_arguments.rb
@@ -46,7 +46,7 @@ module Orbf
 
       def decorate_with_facts(orgunits)
         orgunits.map do |org_unit|
-          OrgUnitWithFacts.new(
+          OrgUnitWithFacts.with(
             orgunit: org_unit,
             facts:   OrgunitFacts.new(org_unit, pyramid).to_facts
           )

--- a/lib/orbf/rules_engine/printers/invoice_printer.rb
+++ b/lib/orbf/rules_engine/printers/invoice_printer.rb
@@ -27,7 +27,7 @@ module Orbf
             array.push(to_total_item(var, solution_as_string))
           end
 
-          Orbf::RulesEngine::Invoice.new(
+          Orbf::RulesEngine::Invoice.with(
             kind:           "package",
             period:         period,
             orgunit_ext_id: orgunit,
@@ -54,7 +54,7 @@ module Orbf
             array.push(to_total_item(var, solution_as_string))
           end
 
-          Orbf::RulesEngine::Invoice.new(
+          Orbf::RulesEngine::Invoice.with(
             kind:           "payment_rule",
             period:         period,
             orgunit_ext_id: org_unit,
@@ -79,7 +79,7 @@ module Orbf
 
         not_exported = export_explanations(explanations, var, solution_as_string)
 
-        Orbf::RulesEngine::TotalItem.new(
+        Orbf::RulesEngine::TotalItem.with(
           formula:      var.formula,
           explanations: explanations,
           value:        solution[var.key],
@@ -127,7 +127,7 @@ module Orbf
 
         return nil if values.values.compact.none?
 
-        Orbf::RulesEngine::ActivityItem.new(
+        Orbf::RulesEngine::ActivityItem.with(
           activity:   activity,
           solution:   values,
           problem:    problem,

--- a/lib/orbf/rules_engine/services/fetch_and_solve.rb
+++ b/lib/orbf/rules_engine/services/fetch_and_solve.rb
@@ -25,7 +25,7 @@ module Orbf
         @exported_values = RulesEngine::Dhis2ValuesPrinter.new(
           solver.variables,
           solver.solution,
-          project.default_combos_ext_ids
+          **project.default_combos_ext_ids
         ).print
 
         exported_values

--- a/lib/orbf/rules_engine/value_object.rb
+++ b/lib/orbf/rules_engine/value_object.rb
@@ -70,7 +70,7 @@ module Orbf
         end
 
         def with(hash)
-          new(hash)
+          new(**hash)
         end
       end
     end

--- a/lib/orbf/rules_engine/value_object.rb
+++ b/lib/orbf/rules_engine/value_object.rb
@@ -1,23 +1,16 @@
 # frozen_string_literal: true
 
-require "active_support/core_ext/class/attribute"
 module Orbf
   module RulesEngine
     class ValueObject
-      class_attribute :_attributes
-      self._attributes = []
-
-      def initialize(hash)
-        check_args_present!(hash)
-        hash.each do |name, value|
-          instance_variable_set("@#{name}", value)
-        end
-        after_init
-        freeze
-      end
+      attr_reader :values
 
       def ==(other)
         eql?(other)
+      end
+
+      def init_with(coder)
+        @values = coder.map.transform_keys(&:to_sym)
       end
 
       def eql?(other)
@@ -31,17 +24,32 @@ module Orbf
       end
 
       def to_h
-        self.class._attributes.each_with_object({}) { |field, hash| hash[field] = send(field) }
+        values
       end
 
       def to_json(options = nil)
         to_h.to_json(options)
       end
 
-      protected
+      def self.Model(*keys)
+        klass = Class.new(self)
+        klass.set_keys(keys)
+        klass
+      end
 
-      def values
-        self.class._attributes.map { |field| send(field) }
+      def self.call(values)
+        o = allocate
+        o.instance_variable_set(:@values, values)
+        o
+      end
+
+      def self.set_keys(keys)
+        im = instance_methods
+        keys.each do |key|
+          meth = :"#{key}="
+          module_eval("def #{key}; @values[:#{key}] end", __FILE__, __LINE__) unless im.include?(key)
+          module_eval("def #{meth}(v); @values[:#{key}] = v end", __FILE__, __LINE__) unless im.include?(meth)
+        end
       end
 
       private
@@ -50,27 +58,11 @@ module Orbf
         # override at will
       end
 
-      def check_args_present!(hash)
-        return if (hash.keys & self.class._attributes).count == self.class._attributes.count
-        raise "#{self.class} : incorrect number of args no such attributes: extra : #{hash.keys - self.class._attributes} missing: #{self.class._attributes - hash.keys}  possible attributes: #{self.class._attributes}"
-      end
-
       class << self
-        def attributes(*attrs)
-          self._attributes = _attributes.dup
-
-          attrs.each { |attr| attribute attr }
-        end
-
-        def attribute(attr)
-          self._attributes = _attributes.concat([attr])
-          define_method attr do
-            instance_variable_get("@#{attr}")
-          end
-        end
-
         def with(hash)
-          new(**hash)
+          i = call(hash)
+          i.send(:after_init)
+          i
         end
       end
     end

--- a/orbf-rules_engine.gemspec
+++ b/orbf-rules_engine.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport"
   spec.add_dependency "colorize"
   spec.add_dependency "hesabu"
-  spec.add_dependency "dentaku", "3.1.0"
+  spec.add_dependency "dentaku", "~> 3.3"
   spec.add_dependency "dhis2", "2.3.8"
   spec.add_dependency "descriptive_statistics"
 

--- a/spec/lib/orbf/rules_engine/builders/contract_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/contract_variables_builder_spec.rb
@@ -41,11 +41,11 @@ RSpec.describe Orbf::RulesEngine::ContractVariablesBuilder do
 
   let(:orgunits) do
     [
-      Orbf::RulesEngine::OrgUnitWithFacts.new(
+      Orbf::RulesEngine::OrgUnitWithFacts.with(
         orgunit: district_orgunit1,
         facts:   { "level" => "2" }
       ),
-      Orbf::RulesEngine::OrgUnitWithFacts.new(
+      Orbf::RulesEngine::OrgUnitWithFacts.with(
         orgunit: Orbf::RulesEngine::OrgUnit.with(
           ext_id:        "2",
           path:          "country_id/county_id/2",
@@ -54,7 +54,7 @@ RSpec.describe Orbf::RulesEngine::ContractVariablesBuilder do
         ),
         facts:   { "level" => "3" }
       ),
-      Orbf::RulesEngine::OrgUnitWithFacts.new(
+      Orbf::RulesEngine::OrgUnitWithFacts.with(
         orgunit: Orbf::RulesEngine::OrgUnit.with(
           ext_id:        "4",
           path:          "country_id/county_id/4",

--- a/spec/lib/orbf/rules_engine/data/org_unit_with_facts_spec.rb
+++ b/spec/lib/orbf/rules_engine/data/org_unit_with_facts_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe Orbf::RulesEngine::OrgUnitWithFacts do
 
   let(:facts) { { sample: "facts" } }
 
-  let(:orgunit_with_facts) { described_class.new(orgunit: orgunit, facts: facts)}
+  let(:orgunit_with_facts) { described_class.with(orgunit: orgunit, facts: facts)}
 
   it "have facts" do
     expect(orgunit_with_facts.facts).to eq(facts)

--- a/spec/lib/orbf/rules_engine/printers/dhis2_values_printer_spec.rb
+++ b/spec/lib/orbf/rules_engine/printers/dhis2_values_printer_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
       it "export no values" do
         result_values = described_class.new(
           [variable_without_mapping],
-          variable_without_mapping.key => 1.5
+          { variable_without_mapping.key => 1.5 }
         ).print
 
         expect(result_values).to eq([])
@@ -52,7 +52,7 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
       it "export values " do
         result_values = described_class.new(
           [variable_with_mapping],
-          variable_with_mapping.key => 1.5
+          { variable_with_mapping.key => 1.5 }
         ).print
 
         expect(result_values).to eq(
@@ -153,7 +153,7 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
       it "export no values" do
         result_values = described_class.new(
           [activity_variable_without_mapping],
-          activity_variable_without_mapping.key => 1.5
+          { activity_variable_without_mapping.key => 1.5 }
         ).print
         expect(result_values).to eq([])
       end
@@ -191,7 +191,7 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
       it "export decimal that are actually integer as integer" do
         result_values = described_class.new(
           [var1, var2],
-          var1.key => 15, var2.key => 15
+          {var1.key => 15, var2.key => 15}
         ).print
         expect(result_values).to eq(
           [
@@ -218,8 +218,8 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
 
         result_values = described_class.new(
           variables,
-          activity_variable_with_exportable_formula_code.key => 15.0,
-          exportable_variable.key                            => false
+          { activity_variable_with_exportable_formula_code.key => 15.0,
+          exportable_variable.key                            => false }
         ).print
 
         expect(result_values).to eq(
@@ -239,8 +239,8 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
 
         result_values = described_class.new(
           variables,
-          activity_variable_with_exportable_formula_code.key => 15.0,
-          exportable_variable.key                            => true
+          { activity_variable_with_exportable_formula_code.key => 15.0,
+          exportable_variable.key                            => true }
         ).print
 
         expect(result_values).to eq(
@@ -300,7 +300,7 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
               formulas: [
                 Orbf::RulesEngine::Formula.new(
                   "quality_score", "31", "",
-                  options
+                  **options
                 ),
                 Orbf::RulesEngine::Formula.new(
                   "exportable", "1 == 1", ""
@@ -367,7 +367,7 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
     def expect_exported_value(variable, solution_value, expected_value, period)
       result_values = described_class.new(
         [variable],
-        variable.key => solution_value
+        { variable.key => solution_value }
       ).print
       expect(result_values).to eq(
         [
@@ -411,7 +411,7 @@ RSpec.describe Orbf::RulesEngine::Dhis2ValuesPrinter do
             formulas: [
               Orbf::RulesEngine::Formula.new(
                 "quality_score", "31", "",
-                options
+                **options
               )
             ]
           )

--- a/spec/lib/orbf/rules_engine/value_object_spec.rb
+++ b/spec/lib/orbf/rules_engine/value_object_spec.rb
@@ -1,18 +1,5 @@
 
 
 RSpec.describe Orbf::RulesEngine::ValueObject do
-  class SampleValueObject < Orbf::RulesEngine::ValueObject
-    attributes :name
-  end
 
-  it "verifies all attributes are passed" do
-    expect { SampleValueObject.new(id: "") }.to raise_error(
-      "SampleValueObject : incorrect number of args no such attributes: extra : [:id] missing: [:name]  possible attributes: [:name]"
-    )
-  end
-
-  it "help with default to_s" do
-    sample = SampleValueObject.new(name:"myname")
-    expect(sample.to_s).to match(/#<SampleValueObject:(.*) @name=\"myname\">/)
-  end
 end


### PR DESCRIPTION
So while testing support for multiple rubies: see #63 (which is also included in this one) we ran into some deprecations in ruby 2.7, these had the following characteritic:

``` ruby
class Hi
  def initialize(hash)
    puts hash
  end
  def self.with(hash)
    new(hash)
  end
end
class HiAgain < Hi
  def initialize(it: "me")
  end
end
hi = Hi.with(it: "me")
HiAgain.with(it: "stinkt")
```

The `Hi.with` is fine, that's just a hash, but when we use the `HiAgain` class with a keyword initializer, ruby will complain that we're using the last arguments as keyword arguments and that will break in ruby 3. (We're passing keyword args to a hash param)

The obvious solution would be to `**` double splat, but that comes at quite a performance cost.

So this takes a different approach, by copying/stealing some code from `Sequel` to have our ValueObject be configured with the `fields` once, and then setting the values to one hash in instance variable.

The good news is that it does shave off some allocations, the bad news is that I don't see any real performance benefit. So keeping this in draft for now. 