### PR TITLE
Fix: Spread out analytics call

### DIFF
--- a/spec/lib/orbf/rules_engine/fetch_data/fetch_data_analytics_spec.rb
+++ b/spec/lib/orbf/rules_engine/fetch_data/fetch_data_analytics_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Orbf::RulesEngine::FetchDataAnalytics do
     WebMock::Config.instance.query_values_notation = nil
   end
 
-  it "combines all arguments and fetch data in one call" do
+  it "splits out the API calls with too many different periods" do
     periods = ["202004", "202005", "202006", "202007","202008", "202009", "202010", "202011"]
     periods_with_years = periods.each_slice(4).map { |slice| slice += ["2020", "2019July"] }
 
@@ -146,7 +146,7 @@ RSpec.describe Orbf::RulesEngine::FetchDataAnalytics do
     end
   end
 
-  it "splits out the API calls with many periods" do
+  it "combines all arguments and fetch data in one call (with limited amount of periods)" do
     request = stub_request(:get, "https://play.dhis2.org/2.28/api/analytics?dimension=dx:dhis2_de_1%3Bdhis2_indic_1%3Bdhis2_de_1.coc_1&dimension=ou:1%3B2&dimension=pe:201601")
               .to_return(status: 200, body: JSON.pretty_generate(
                 "rows" => [

--- a/spec/lib/orbf/rules_engine/fetch_data/fetch_data_analytics_spec.rb
+++ b/spec/lib/orbf/rules_engine/fetch_data/fetch_data_analytics_spec.rb
@@ -100,6 +100,53 @@ RSpec.describe Orbf::RulesEngine::FetchDataAnalytics do
   end
 
   it "combines all arguments and fetch data in one call" do
+    periods = ["202004", "202005", "202006", "202007","202008", "202009", "202010", "202011"]
+    periods_with_years = periods.each_slice(4).map { |slice| slice += ["2020", "2019July"] }
+
+    package_arguments = periods_with_years.map do |periods|
+      Orbf::RulesEngine::PackageArguments.with(
+        periods:          periods,
+        orgunits:         Orbf::RulesEngine::OrgUnits.new(
+          orgunits: [orgunit_1], package: package
+        ),
+        datasets_ext_ids: [],
+        package:          package
+      )
+    end
+
+    fetcher = described_class.new(dhis2_connection, package_arguments)
+
+    stubbed_requests = periods.each_slice(described_class::MAX_PERIODS_PER_FETCH).map do |period_slice|
+      pe = period_slice.join(";")
+      rows = period_slice.inject([]) do |result, period|
+        result << ["dhis2_de_1", orgunit_1.ext_id, period, "1.4"]
+        result << ["dhis2_de_1.coc_1", orgunit_1.ext_id, period, "3.2"]
+        result << ["dhis2_de_1.coc_2", orgunit_1.ext_id, period, "NaN"]
+        result
+      end
+      stub_request(:get, "https://play.dhis2.org/2.28/api/analytics?dimension=dx:dhis2_de_1%3Bdhis2_indic_1%3Bdhis2_de_1.coc_1&dimension=ou:1&dimension=pe:#{pe}")
+              .to_return(status: 200, body: JSON.pretty_generate(
+                "rows" => rows
+              ), headers: {})
+    end
+    fetcher = described_class.new(dhis2_connection, package_arguments)
+    values = fetcher.call
+    stubbed_requests.each {|sr| expect(sr).to have_been_made.once }
+
+
+    periods.each do |period|
+
+      expect(values).to include({ "attributeOptionCombo" => "default",
+                                  "categoryOptionCombo"  => "default",
+                                  "dataElement"          => "dhis2_de_1",
+                                  "orgUnit"              => "1",
+                                  "period"               => period,
+                                  "value"                => "1.4",
+                                  "origin"               => "analytics" })
+    end
+  end
+
+  it "splits out the API calls with many periods" do
     request = stub_request(:get, "https://play.dhis2.org/2.28/api/analytics?dimension=dx:dhis2_de_1%3Bdhis2_indic_1%3Bdhis2_de_1.coc_1&dimension=ou:1%3B2&dimension=pe:201601")
               .to_return(status: 200, body: JSON.pretty_generate(
                 "rows" => [
@@ -108,6 +155,8 @@ RSpec.describe Orbf::RulesEngine::FetchDataAnalytics do
                   ["dhis2_de_1.coc_2", orgunit_1.ext_id, "201601", "NaN"]
                 ]
               ), headers: {})
+
+    values = described_class.new(dhis2_connection, package_arguments)
 
     values = fetch_data.call
 


### PR DESCRIPTION
Instead of doing one request for all the periods we now limit it to 5 periods per call and combine the results of those.

For future reference, this was called with these periods:

[["202004", "202005", "202006", "2020", "2019July"], ["2020Q2", "202004", "202005", "202006", "2020", "2019July"], ["202004", "202005", "202006", "2020", "2019July"], ["2020Q2", "202004", "202005", "202006", "2020", "2019July"], ["202004", "202005", "202006", "2020", "2019July"], ["202004", "202005", "202006", "2020", "2019July"], ["202004", "202005", "202006", "2020", "2019July"], ["202004", "202005", "202006", "2020", "2019July"], ["2020Q2", "2020", "2019July"], ["2020Q2", "2020", "2019July"], ["2020Q2", "2020", "2019July"], ["201901", "201902", "201903", "201904", "201905", "201906", "201907", "201908", "201909", "201910", "201911", "201912", "2019Q1", "2019Q2", "2019Q3", "2019Q4", "2019", "2020Q2", "2020", "2019July"], ["202004", "202005", "202006", "2020", "2019July"], ["202004", "202005", "202006", "2020", "2019July"], ["2020Q2", "2020", "2019July"]]

Which broke fetching analytics