### PR TITLE
Expose variable key on total item

### DIFF
--- a/lib/orbf/rules_engine/data/invoice.rb
+++ b/lib/orbf/rules_engine/data/invoice.rb
@@ -41,10 +41,11 @@ module Orbf
     end
 
     class TotalItem < Orbf::RulesEngine::ValueObject
-      attributes :formula, :explanations, :value, :not_exported
-      attr_reader :formula, :explanations, :value, :not_exported
+      attributes :key, :formula, :explanations, :value, :not_exported
+      attr_reader :key, :formula, :explanations, :value, :not_exported
 
-      def initialize(formula: nil, explanations: nil, value: nil, not_exported:)
+      def initialize(key:nil, formula: nil, explanations: nil, value: nil, not_exported:)
+        @key = key
         @formula = formula
         @explanations = explanations
         @value = value

--- a/lib/orbf/rules_engine/printers/invoice_printer.rb
+++ b/lib/orbf/rules_engine/printers/invoice_printer.rb
@@ -80,6 +80,7 @@ module Orbf
         not_exported = export_explanations(explanations, var, solution_as_string)
 
         Orbf::RulesEngine::TotalItem.new(
+          key: var.key,
           formula:      var.formula,
           explanations: explanations,
           value:        solution[var.key],

--- a/lib/orbf/rules_engine/printers/invoice_printer.rb
+++ b/lib/orbf/rules_engine/printers/invoice_printer.rb
@@ -78,9 +78,8 @@ module Orbf
         ]
 
         not_exported = export_explanations(explanations, var, solution_as_string)
-
         Orbf::RulesEngine::TotalItem.new(
-          key: var.key,
+          key:          var.key,
           formula:      var.formula,
           explanations: explanations,
           value:        solution[var.key],

--- a/spec/lib/orbf/rules_engine/printers/invoice_printer_spec.rb
+++ b/spec/lib/orbf/rules_engine/printers/invoice_printer_spec.rb
@@ -128,6 +128,7 @@ RSpec.describe Orbf::RulesEngine::InvoicePrinter do
 
       expect(payment_invoice.activity_items).to eq([])
       expect(payment_invoice.total_items.first.to_h).to eq(
+        key:          "rbf_amount_for_1_and_201601",
         formula:      variable_payment.formula,
         explanations: ["quality_score * 100", "120", "120\n\t"],
         value:        120,

--- a/spec/lib/orbf/rules_engine/printers/invoice_printer_spec.rb
+++ b/spec/lib/orbf/rules_engine/printers/invoice_printer_spec.rb
@@ -155,6 +155,7 @@ RSpec.describe Orbf::RulesEngine::InvoicePrinter do
       expect(invoice.total_items).to eq(
         [
           Orbf::RulesEngine::TotalItem.with(
+            key:          "quality_score_for_1_and_201601",
             formula:      variable_total.formula,
             explanations: %W[31 31 31\n\t],
             value:        31,


### PR DESCRIPTION
Expose the variable key on total item to be able to check usage or dependencies between total item or activity item.
Cfr hesabu manager request