### PR TITLE
Ensure bug with duplicate periods does not happen

### DIFF
--- a/lib/orbf/rules_engine/fetch_data/fetch_data_analytics.rb
+++ b/lib/orbf/rules_engine/fetch_data/fetch_data_analytics.rb
@@ -12,10 +12,6 @@ module Orbf
         return [] if analytics_activity_states.none?
 
         combined_response = Array(without_yearly_periods).each_slice(MAX_PERIODS_PER_FETCH).inject({}) do |result, period_slice|
-          puts({periods:            period_slice.join(";"),
-          organisation_units: orgunit_ext_ids,
-          data_elements:      data_elements}.to_json)
-
           analytics_response = dhis2_connection.analytics.list(
             periods:            period_slice.join(";"),
             organisation_units: orgunit_ext_ids,

--- a/lib/orbf/rules_engine/fetch_data/fetch_data_analytics.rb
+++ b/lib/orbf/rules_engine/fetch_data/fetch_data_analytics.rb
@@ -75,7 +75,7 @@ module Orbf
       end
 
       def without_yearly_periods
-        package_arguments.map(&:periods).map { |p| p[0..-3] }.uniq.flatten
+        package_arguments.map(&:periods).map { |p| p[0..-3] }.flatten.uniq.sort
       end
     end
   end

--- a/lib/orbf/rules_engine/fetch_data/periods_resolver.rb
+++ b/lib/orbf/rules_engine/fetch_data/periods_resolver.rb
@@ -8,6 +8,7 @@ module Orbf
         @invoice_period = invoice_period
       end
 
+      # Will return an array of periods, guaranteed to be unique.
       def call
         from_values_span(package, invoice_period).merge(
           from_package_frequency(package, invoice_period)

--- a/spec/lib/orbf/rules_engine/fetch_data/periods_resolver_spec.rb
+++ b/spec/lib/orbf/rules_engine/fetch_data/periods_resolver_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe Orbf::RulesEngine::PeriodsResolver do
             Orbf::RulesEngine::Formula.new(
               "increase",
               "safe_div(achieved,sum(%{achieved_previous_year_same_quarter_monthly_values}/4)"
+            ),
+            Orbf::RulesEngine::Formula.new(
+              "increase",
+              "safe_div(achieved,sum(%{achieved_last_24_months_window_values})"
             )
           ]
         )

--- a/spec/lib/orbf/rules_engine/fetch_data/periods_resolver_spec.rb
+++ b/spec/lib/orbf/rules_engine/fetch_data/periods_resolver_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Orbf::RulesEngine::PeriodsResolver do
             ),
             Orbf::RulesEngine::Formula.new(
               "increase",
-              "safe_div(achieved,sum(%{achieved_last_24_months_window_values})"
+              "safe_div(achieved,sum(%{achieved_last_12_months_window_values})"
             )
           ]
         )
@@ -56,8 +56,16 @@ RSpec.describe Orbf::RulesEngine::PeriodsResolver do
   end
 
   it "resolve periods from package frequency and activity span _values" do
-    expect(described_class.new(quantity_package, "2016Q1").call).to eq(
-      %w[201501 201502 201503 201601 201602 201603 2016 2015July]
-    )
+    previous_year_same_quarter = [
+      "201501", "201502", "201503", "201504", "201505"
+    ]
+    last_12_months = [
+      "201603", "201602", "201601", "201512", "201511",
+      "201510", "201509", "201508", "201507", "201506",
+      "201505", "201504"
+    ]
+    yearlies = ["2016", "2015July"]
+    expected = (previous_year_same_quarter + last_12_months).uniq.sort + yearlies
+    expect(described_class.new(quantity_package, "2016Q1").call).to eq(expected)
   end
 end


### PR DESCRIPTION
  Fix: Analytics call ran multiple times for same period
    
    If you had multiple packages, which had formulas which returned a
    similar set of periods, the overlapping periods would result in a
    double call.
    
    This only happened if you had more than 5 periods (the point at which
    we split the analytics call into multiple calls), so even if you had
    overlapping ones, if the total was not over 5, it would work.
    
    The reason the test didn't catch this was that all the
    package_arguments were set up with the same array of periods, so when
    we ran:
    
        map(&:periods).uniq
    
    It compared the arrays, instead of the elements, and because the
    arrays were exactly the same, we had no problems.
    
    I've made the spec a bit more wordy about this, and set up a scenario
    where we are triggering this behavior.
    
    I've also sorted the resulting periods, mostly because this reads
    nicer when debugging the calls. (And much easier to stub the requests)
