### PR TITLE
Handle new view format

### DIFF
--- a/lib/orbf/rules_engine/services/contract_service.rb
+++ b/lib/orbf/rules_engine/services/contract_service.rb
@@ -87,7 +87,9 @@ module Orbf
       private
 
       def to_event(row, indexes)
-        data_vals = JSON.parse(row[indexes.fetch("data_values")]["value"])
+
+        raw_data_values = row[indexes.fetch("data_values")]
+        data_vals = raw_data_values.is_a?(String) ? JSON.parse(raw_data_values) : JSON.parse(raw_data_values["value"])
         data_values = data_vals.keys.map do |k|
           data_vals[k]["dataElement"] = k
           data_vals[k]

--- a/spec/fixtures/dhis2/contract_raw_events_v2.json
+++ b/spec/fixtures/dhis2/contract_raw_events_v2.json
@@ -1,0 +1,111 @@
+{
+  "pager": { "page": 1, "pageCount": 1698, "total": 3396, "pageSize": 2 },
+  "listGrid": {
+    "metaData": {},
+    "headerWidth": 6,
+    "subtitle": "all program events",
+    "width": 6,
+    "title": "all program events",
+    "height": 2,
+    "headers": [
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "event id",
+        "column": "event_id",
+        "type": "java.lang.String"
+      },
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "data values",
+        "column": "data_values",
+        "type": "java.lang.String"
+      },
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "orgunitid",
+        "column": "org_unit_id",
+        "type": "java.lang.String"
+      },
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "orgunitname",
+        "column": "org_unit_name",
+        "type": "java.lang.String"
+      },
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "program_id",
+        "column": "program_id",
+        "type": "java.lang.String"
+      },
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "program_stage_id",
+        "column": "program_stage_id",
+        "type": "java.lang.String"
+      },
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "event date",
+        "column": "event_date",
+        "type": "java.lang.String"
+      },
+      {
+        "hidden": false,
+        "meta": false,
+        "name": "org unit path",
+        "column": "org_unit_path",
+        "type": "java.lang.String"
+      }
+    ],
+    "rows": [
+      [
+        "OgVbqGV2WMH",
+        "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": \"GROUP_CSI_1_CODE\"}, \"extra2FJDgX0U\":{\"value\":\"GROUP_RURAL_CODE\" }}" ,
+        "1",
+        "CSI A",
+        "TwcqxaLn11C",
+        "gHPyjsmOXHy"
+      ],
+      [
+        "zIU4tW3NRER",
+        "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\" }, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\" }, \"xti2FJDgX0U\": {\"value\": \"GROUP_CSI_2_CODE\" }, \"extra2FJDgX0U\":{\"value\":\"GROUP_URBAN_CODE\" }}",
+        "2",
+        "CSI B",
+        "TwcqxaLn11C",
+        "gHPyjsmOXHy"
+      ],
+      [
+        "zIU4tW3NRER",
+        "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\" }, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\" }, \"xti2FJDgX0U\": {\"value\": \"GROUP_3_CODE\" }}",
+        "3",
+        "Hospital District",
+        "TwcqxaLn11C",
+        "gHPyjsmOXHy"
+      ],
+      [
+        "zIU4tW3NRER",
+        "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": null}, \"extra2FJDgX0U\": {\"value\": \"GROUP_X_CODE\"}, \"EBDWBYsJvuz\":{\"value\": \"province_id\"}}",
+        "X",
+        "kl Lareme Centre de Santé",
+        "TwcqxaLn11C",
+        "gHPyjsmOXHy"
+      ],
+      [
+        "zIU4tW3NRER",
+        "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": null}, \"extra2FJDgX0U\": {\"value\": \"GROUP_PROVINCE_CODE\"}, \"EBDWBYsJvuz\":{\"value\": \"province_id\"}}",
+        "province_id",
+        "Province",
+        "TwcqxaLn11C",
+        "gHPyjsmOXHy"
+      ]
+    ]
+  }
+}

--- a/spec/lib/orbf/rules_engine/fetch_data/contract_orgunits_resolver_spec.rb
+++ b/spec/lib/orbf/rules_engine/fetch_data/contract_orgunits_resolver_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe Orbf::RulesEngine::ContractOrgunitsResolver do
 
   def stub_contract_program
     stub_request(:get, "https://play.dhis2.org/api/sqlViews/DHIS2ALLEVENTSQLVIEWID/data.json?paging=false&var=programId:DHIS2CONTRACTPROGRAMID")
-      .to_return(status: 200, body: fixture_content(:dhis2, "contract_raw_events.json"))
+      .to_return(status: 200, body: fixture_content(:dhis2, "contract_raw_events_v2.json"))
     stub_request(:get, "https://play.dhis2.org/api/programs/DHIS2CONTRACTPROGRAMID?fields=id,name,programStages%5BprogramStageDataElements%5BdataElement%5Bid,name,code,optionSet%5Bid,name,code,options%5Bid,code,name%5D%5D%5D%5D&paging=false")
       .to_return(status: 200, body: fixture_content(:dhis2, "contract_program.json"))
   end


### PR DESCRIPTION
since 2.35 same sql  produce empty datavalues field
I've adaped the query to "cast as text" the jsonb field `(programstageinstance.eventdatavalues::text) as data_values ,`

```
select 
programstageinstance.uid as event_id, 
programstageinstance.executiondate as event_date, 
program.uid as program_id, 
programStage.uid as program_stage_id,
(programstageinstance.eventdatavalues::text) as data_values ,
organisationunit.uid  as org_unit_id, 
organisationunit.name as org_unit_name, 
organisationunit.path as org_unit_path,
_orgunitstructure.*
from programstageinstance 
join programstage ON programstage.programstageid = programstageinstance.programstageid join program ON program.programid = programstage.programid 
join organisationunit ON organisationunit.organisationunitid = programstageinstance.organisationunitid 
join _orgunitstructure ON _orgunitstructure.organisationunitid = programstageinstance.organisationunitid 
where  program.uid = '${programId}' and programstageinstance.deleted is false order by programstageinstanceid desc 
```
