### PR TITLE
Handle period start/end

### DIFF
--- a/lib/orbf/rules_engine/builders/decision_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/decision_variables_builder.rb
@@ -12,8 +12,12 @@ module Orbf
       end
 
       def to_variables
-        decision_tables = package.activity_rules.flat_map(&:decision_tables)
+        decision_tables = package.activity_rules
+                                 .flat_map(&:decision_tables)
+                                 .select { |decision_table| decision_table.match_period?(period) }
+
         return [] if decision_tables.none?
+
         decision_tables.each_with_object([]) do |decision_table, array|
           variables = decision_variables(decision_table)
           array.push(*variables)

--- a/lib/orbf/rules_engine/builders/package_decision_variables_builder.rb
+++ b/lib/orbf/rules_engine/builders/package_decision_variables_builder.rb
@@ -12,8 +12,12 @@ module Orbf
       end
 
       def to_variables
-        decision_tables = package.package_rules.flat_map(&:decision_tables)
+        decision_tables = package.package_rules
+                                 .flat_map(&:decision_tables)
+                                 .select { |decision_table| decision_table.match_period?(period) }
+
         return [] if decision_tables.none?
+
         decision_tables.each_with_object([]) do |decision_table, array|
           variables = decision_variables(decision_table)
           array.push(*variables)

--- a/lib/orbf/rules_engine/data/decision_table.rb
+++ b/lib/orbf/rules_engine/data/decision_table.rb
@@ -4,17 +4,25 @@ require "csv"
 module Orbf
   module RulesEngine
     class DecisionTable
-      attr_reader :rules
+      attr_reader :rules, :start_period, :end_period
 
       HEADER_SEPERATOR = ":"
 
-      def initialize(csv_string)
+      def initialize(csv_string, start_period:, end_period:)
+        @start_period = start_period
+        @end_period = end_period
         csv = CSV.parse(csv_string, headers: true)
         @headers = csv.headers.compact.map(&:freeze)
 
         @rules = csv.each_with_index.map do |row, index|
           DecisionRule.new(@headers, row, index)
         end
+      end
+
+      def match_period?(period)
+        return true unless @start_period && @end_period
+
+        start_period <= period && period <= end_period
       end
 
       def find(raw_hash)

--- a/spec/lib/orbf/rules_engine/builders/activity_formula_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/activity_formula_variables_builder_spec.rb
@@ -231,7 +231,7 @@ RSpec.describe Orbf::RulesEngine::ActivityFormulaVariablesBuilder do
               Orbf::RulesEngine::DecisionTable.new(%(in:activity_code,in:level_2,out:equity_bonus
                 act1,county_id,1
                 act2,county_id,2
-              ))
+              ), start_period: nil, end_period: nil)
             ]
           )
         ]
@@ -378,7 +378,7 @@ RSpec.describe Orbf::RulesEngine::ActivityFormulaVariablesBuilder do
               Orbf::RulesEngine::DecisionTable.new(%(in:activity_code,in:level_2,out:equity_bonus
                 act1,county_id,1
                 act2,county_id,2
-              ))
+              ), start_period: nil, end_period: nil)
             ]
           )
         ]

--- a/spec/lib/orbf/rules_engine/builders/contract_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/contract_variables_builder_spec.rb
@@ -171,7 +171,7 @@ RSpec.describe Orbf::RulesEngine::ContractVariablesBuilder do
                 1,false
                 2,false
                 *,true
-              ))
+              ), start_period: nil, end_period: nil)
             ]
           )
         ]

--- a/spec/lib/orbf/rules_engine/builders/decision_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/decision_variables_builder_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Orbf::RulesEngine::DecisionVariablesBuilder do
             Orbf::RulesEngine::DecisionTable.new(%(in:activity_code,in:level_2,out:equity_bonus
                   act1,county_id,1
                   act2,county_id,2
-                ))
+                ), start_period: nil, end_period: nil)
           ]
         )
       ]

--- a/spec/lib/orbf/rules_engine/builders/decision_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/decision_variables_builder_spec.rb
@@ -104,4 +104,126 @@ RSpec.describe Orbf::RulesEngine::DecisionVariablesBuilder do
   it "build" do
     expect(builder.to_variables).to eq_vars expected_variables
   end
+
+  describe "2 decision tables with periods" do
+    let(:package) do
+      Orbf::RulesEngine::Package.new(
+        code:       :facility,
+        kind:       :single,
+        frequency:  :quarterly,
+        activities: activities,
+        rules:      [
+          Orbf::RulesEngine::Rule.new(
+            kind:            :activity,
+            formulas:        [],
+            decision_tables: [
+              Orbf::RulesEngine::DecisionTable.new(%(in:activity_code,in:level_2,out:equity_bonus
+                    act1,county_id,1
+                    act2,county_id,2
+                  ), start_period: "2020Q1", end_period: "2020Q1"),
+              Orbf::RulesEngine::DecisionTable.new(%(in:activity_code,in:level_2,out:equity_bonus
+                  act1,county_id,4
+                  act2,county_id,8
+                ), start_period: "2020Q2", end_period: "2020Q4")
+
+            ]
+          )
+        ]
+      )
+    end
+    let(:builder2020Q1) do
+      Orbf::RulesEngine::DecisionVariablesBuilder.new(
+        package,
+        Orbf::RulesEngine::OrgUnits.new(orgunits: orgunits, package: package),
+        "2020Q1"
+      )
+    end
+
+    let(:expected_variables_2020Q1) do
+      [
+        Orbf::RulesEngine::Variable.with(
+          period:         "2020Q1",
+          key:            "facility_act1_equity_bonus_for_1_and_2020q1",
+          expression:     "1",
+          state:          "equity_bonus",
+          activity_code:  "act1",
+          type:           "activity_rule_decision",
+          orgunit_ext_id: "1",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        ),
+
+        Orbf::RulesEngine::Variable.with(
+          period:         "2020Q1",
+          key:            "facility_act2_equity_bonus_for_1_and_2020q1",
+          expression:     "2",
+          state:          "equity_bonus",
+          activity_code:  "act2",
+          type:           "activity_rule_decision",
+          orgunit_ext_id: "1",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        )
+      ]
+    end
+
+    let(:builder2020Q2) do
+      Orbf::RulesEngine::DecisionVariablesBuilder.new(
+        package,
+        Orbf::RulesEngine::OrgUnits.new(orgunits: orgunits, package: package),
+        "2020Q2"
+      )
+    end
+
+    let(:expected_variables_2020Q2) do
+      [
+        Orbf::RulesEngine::Variable.with(
+          period:         "2020Q2",
+          key:            "facility_act1_equity_bonus_for_1_and_2020q2",
+          expression:     "4",
+          state:          "equity_bonus",
+          activity_code:  "act1",
+          type:           "activity_rule_decision",
+          orgunit_ext_id: "1",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        ),
+
+        Orbf::RulesEngine::Variable.with(
+          period:         "2020Q2",
+          key:            "facility_act2_equity_bonus_for_1_and_2020q2",
+          expression:     "8",
+          state:          "equity_bonus",
+          activity_code:  "act2",
+          type:           "activity_rule_decision",
+          orgunit_ext_id: "1",
+          formula:        nil,
+          package:        package,
+          payment_rule:   nil
+        )
+      ]
+    end
+
+    let(:builder2016Q1) do
+      Orbf::RulesEngine::DecisionVariablesBuilder.new(
+        package,
+        Orbf::RulesEngine::OrgUnits.new(orgunits: orgunits, package: package),
+        "2016Q1"
+      )
+    end
+
+    it "build with first decision table in 2020Q1, first decision table values" do
+      expect(builder2020Q1.to_variables).to eq_vars expected_variables_2020Q1
+    end
+    it "build with first decision table in 2020Q1, second decision table values" do
+      expect(builder2020Q2.to_variables).to eq_vars expected_variables_2020Q2
+    end
+
+    it "build with first decision table in 2016Q1, no variables" do
+      expect(builder2016Q1.to_variables).to eq_vars []
+    end
+  end
 end

--- a/spec/lib/orbf/rules_engine/builders/package_decision_variables_builder_spec.rb
+++ b/spec/lib/orbf/rules_engine/builders/package_decision_variables_builder_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe Orbf::RulesEngine::PackageDecisionVariablesBuilder do
                   worldbank,fosa,1000,2000
                   worldbank,hospital,3000,4000
                   usaid,hospital,3000,4000
-                ))
+                ), start_period: nil, end_period: nil)
           ]
         )
       ]

--- a/spec/lib/orbf/rules_engine/data/decision_table_spec.rb
+++ b/spec/lib/orbf/rules_engine/data/decision_table_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Orbf::RulesEngine::DecisionTable do
          belgium,namur,*,1
          belgium,brussel,*,2
          belgium,brussel,kk,2
-       ))
+       ), start_period: nil, end_period: nil)
   end
 
   describe "#to_s" do
@@ -46,6 +46,41 @@ RSpec.describe Orbf::RulesEngine::DecisionTable do
 
     it "return nil if none matching" do
       expect(table.find(level_1: "holland", level_2: "houtsiplou")).to be nil
+    end
+  end
+
+  describe "#match_period?" do
+    let(:table_with_periods) do
+      described_class.new(%(in:level_1,in:level_2,in:level_3,out:equity_bonus
+         belgium,*,*,11
+         belgium,namur,*,1
+         belgium,brussel,*,2
+         belgium,brussel,kk,2
+       ), start_period: "2020Q1", end_period: "2020Q3")
+    end
+
+    it "matches if no start/end then" do 
+      expect(table.match_period?("2020Q1")).to be true
+    end
+
+    it "starts inclusive" do 
+      expect(table_with_periods.match_period?("2020Q1")).to be true
+    end
+
+    it "ends inclusive" do 
+      expect(table_with_periods.match_period?("2020Q3")).to be true
+    end
+
+    it "handle what's in between" do 
+      expect(table_with_periods.match_period?("2020Q2")).to be true
+    end
+
+    it "doesn't match just before" do 
+      expect(table_with_periods.match_period?("2019Q4")).to be false
+    end
+
+    it "doesn't match just after" do 
+      expect(table_with_periods.match_period?("2020Q4")).to be false
     end
   end
 end

--- a/spec/mw_spec.rb
+++ b/spec/mw_spec.rb
@@ -139,7 +139,7 @@ RSpec.describe "Malawi System" do
                 dhmt_1,public,false
                 dhmt_2,private,true
                 *,*,true
-              ))
+              ), start_period: nil, end_period: nil)
           ]
         ),
         Orbf::RulesEngine::Rule.new(


### PR DESCRIPTION
Complex pbf often use decision tables and contract information like which equity category they belong to because using data stored in dhis2 at the country level is not scalable since there's combinatorial explosion in the number of data elements to feed (eg # of activities x # of categories)

So to ease the changes of prices over time and keeping track of them (without needing to version completely the orbf project)
We allow to specify start/end periods on decision tables

![image](https://user-images.githubusercontent.com/371692/116675258-eca70980-a9a5-11eb-91a4-78fd8c941df1.png)

and then the engine will "pick up" the decision table matching the periods.

The periods should match the "package frequency" and are "inclusive at start and end level" (allowing for exemple a decision table to apply for only a quarter)

Note this change can even occur "per month" in the middle of the quarter as shown here.
This makes the decision tables probably the best way to manage incentives now (prices/max points/...).
And allows also formulas to use some "period info" to behave a bit differently between one period to another.

![image](https://user-images.githubusercontent.com/371692/116676269-114fb100-a9a7-11eb-80b1-9542e0d58b20.png)
