### PR TITLE
Don't depend on orgunit lookup when project based contract

### DIFF
--- a/lib/orbf/rules_engine/data/contract.rb
+++ b/lib/orbf/rules_engine/data/contract.rb
@@ -27,6 +27,10 @@ module Orbf
         [start_period.to_i - period_start_month.to_i, end_period.to_i - period_start_month.to_i].min
       end
 
+      def org_unit
+        Orbf::RulesEngine::OrgUnit.new(ext_id: @org_unit["id"], name: @org_unit["name"], path: @org_unit["path"], group_ext_ids: [])
+      end
+
       def org_unit_id
         @org_unit["id"]
       end

--- a/lib/orbf/rules_engine/fetch_data/contract_orgunits_resolver.rb
+++ b/lib/orbf/rules_engine/fetch_data/contract_orgunits_resolver.rb
@@ -49,7 +49,8 @@ module Orbf
       def handle_target_org_units
         target_codes = pyramid.groups(package.target_org_unit_group_ext_ids).map(&:code_downcase)
         target_contracts = @contract_service.for_groups(target_codes, @period)
-        org_units_set = pyramid.org_units_for(target_contracts.map(&:org_unit_id))
+
+        org_units_set = target_contracts.map(&:org_unit)
         org_units_set = org_units_set.keep_if { |orgunit| orgunit.path.start_with?(main_orgunit.path)}
         org_units_set.delete(main_orgunit)
         org_units_set.to_a.unshift(main_orgunit)
@@ -59,7 +60,8 @@ module Orbf
         return [] unless within_package_groups?
 
         subcontracts = @contract_service.for_subcontract(main_orgunit.ext_id, @period)
-        org_units_set = pyramid.org_units_for(subcontracts.map(&:org_unit_id))
+        
+        org_units_set = subcontracts.map(&:org_unit)
         org_units_set_size = org_units_set.size
         org_units_set.delete(main_orgunit) unless include_main_orgunit
         orgunits = org_units_set.to_a.unshift(main_orgunit)

--- a/lib/orbf/rules_engine/fetch_data/contract_orgunits_resolver.rb
+++ b/lib/orbf/rules_engine/fetch_data/contract_orgunits_resolver.rb
@@ -50,7 +50,7 @@ module Orbf
         target_codes = pyramid.groups(package.target_org_unit_group_ext_ids).map(&:code_downcase)
         target_contracts = @contract_service.for_groups(target_codes, @period)
 
-        org_units_set = target_contracts.map(&:org_unit)
+        org_units_set = Set.new(target_contracts.map(&:org_unit))
         org_units_set = org_units_set.keep_if { |orgunit| orgunit.path.start_with?(main_orgunit.path)}
         org_units_set.delete(main_orgunit)
         org_units_set.to_a.unshift(main_orgunit)
@@ -61,7 +61,7 @@ module Orbf
 
         subcontracts = @contract_service.for_subcontract(main_orgunit.ext_id, @period)
         
-        org_units_set = subcontracts.map(&:org_unit)
+        org_units_set = Set.new(subcontracts.map(&:org_unit))
         org_units_set_size = org_units_set.size
         org_units_set.delete(main_orgunit) unless include_main_orgunit
         orgunits = org_units_set.to_a.unshift(main_orgunit)

--- a/spec/fixtures/dhis2/contract_raw_events-contract-zone-mali.json
+++ b/spec/fixtures/dhis2/contract_raw_events-contract-zone-mali.json
@@ -72,7 +72,9 @@
         "1",
         "CSI A",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        ""
       ],
       [
         "zIU4tW3NRER",
@@ -80,7 +82,9 @@
         "2",
         "CSI B",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        ""
       ],
       [
         "zIU4tW3NRER",
@@ -88,7 +92,9 @@
         "3",
         "Hospital District",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        ""
       ],
       [
         "zIU4tW3NRER",
@@ -96,7 +102,9 @@
         "X",
         "kl Lareme Centre de Santé",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        ""
       ],
       [
         "zIU4tW3NRER",
@@ -104,7 +112,9 @@
         "province_id",
         "Province",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        ""
       ]
     ]
   }

--- a/spec/fixtures/dhis2/contract_raw_events_v2.json
+++ b/spec/fixtures/dhis2/contract_raw_events_v2.json
@@ -68,11 +68,13 @@
     "rows": [
       [
         "OgVbqGV2WMH",
-        "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": \"GROUP_CSI_1_CODE\"}, \"extra2FJDgX0U\":{\"value\":\"GROUP_RURAL_CODE\" }}" ,
+        "{\"LvHWK2BkIJT\": {\"value\": \"2018-06-01\"}, \"vqE7cqNXVYK\": {\"value\": \"2021-12-31\"}, \"xti2FJDgX0U\": {\"value\": \"GROUP_CSI_1_CODE\"}, \"extra2FJDgX0U\":{\"value\":\"GROUP_RURAL_CODE\" }}",
         "1",
         "CSI A",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        "country_id/province_id/1"
       ],
       [
         "zIU4tW3NRER",
@@ -80,7 +82,9 @@
         "2",
         "CSI B",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        "country_id/province_id/2"
       ],
       [
         "zIU4tW3NRER",
@@ -88,7 +92,9 @@
         "3",
         "Hospital District",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        "path/dfdf/"
       ],
       [
         "zIU4tW3NRER",
@@ -96,7 +102,9 @@
         "X",
         "kl Lareme Centre de Santé",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        "path/dfdf/"
       ],
       [
         "zIU4tW3NRER",
@@ -104,7 +112,9 @@
         "province_id",
         "Province",
         "TwcqxaLn11C",
-        "gHPyjsmOXHy"
+        "gHPyjsmOXHy",
+        "",
+        "country_id/province_id"
       ]
     ]
   }


### PR DESCRIPTION
The problem :

When adding new orgunits and new contracts, hesabu still rely on the pyramid to lookup orgunits in the "past" periods. But these orgunit are not in the "past" pyramids. Causing `pyramid.org_units_for` to return a array containing a nil element for the new orgunit, and further ending on errors like `NoMethodError undefined method 'path' for nil:NilClass` in the code checking if the orgunit is "under" the main orgunit.

The solution :

I stopped using `pyramid.org_units_for` in favor of the `contract.org_unit`. Since the group ids are no more used since we used the contracts fields for that, I think it's safe to have an empty group ext ids. The only fact used by the orgunit it self is the path but should be equivalent to what the pyramid would had. (The fixture is not 100% compliant in dhis2 because the path startswith a /, but I kept it like that to avoid "doubting" I changed the spec to actually work)

I hope I didn't miss an important fact here but it looks ok in the spec ;)

