### PR TITLE
Fallback on contract orgunit

### DIFF
--- a/lib/orbf/rules_engine/fetch_data/resolve_arguments.rb
+++ b/lib/orbf/rules_engine/fetch_data/resolve_arguments.rb
@@ -10,6 +10,12 @@ module Orbf
         @invoicing_period = invoicing_period
         @main_orgunit = pyramid.org_unit(orgunit_ext_id)
         @contract_service = contract_service
+
+        if @main_orgunit.nil? && contract_service
+          main_contract = contract_service.for(orgunit_ext_id, invoicing_period)
+          @main_orgunit = main_contract.org_unit if main_contract
+        end
+
         raise "unknown orgunit '#{orgunit_ext_id}'" unless @main_orgunit
       end
 


### PR DESCRIPTION
The previous PR  https://github.com/BLSQ/orbf-rules_engine/pull/82 was mainly focusing on "subcontractors" or "orgunits under"
but I forgot to handle the main orgunit. This PR tries to fix this.