### PR TITLE
Ethiopian calendar might end up as invalid date in gregorian calendar…

### DIFF
--- a/lib/orbf/rules_engine/services/ethiopian_calendar.rb
+++ b/lib/orbf/rules_engine/services/ethiopian_calendar.rb
@@ -25,7 +25,15 @@ module Orbf
         eyear = 4 * ((jdn - era) / 1461) + r / 365 - r / 1460
         emonth = (n / 30) + 1
         eday = n.modulo(30) + 1
-        Date.new(eyear, emonth, eday)
+        begin
+          Date.new(eyear, emonth, eday)
+        rescue ArgumentError
+          begin
+            Date.new(eyear, emonth, eday - 1)
+          rescue ArgumentError
+            Date.new(eyear, emonth, eday - 2)
+        end
+        end
       end
 
       def to_iso(ethiopic)

--- a/spec/lib/orbf/rules_engine/services/ethiopian_calendar_spec.rb
+++ b/spec/lib/orbf/rules_engine/services/ethiopian_calendar_spec.rb
@@ -39,6 +39,37 @@ RSpec.describe Orbf::RulesEngine::EthiopianCalendar do
     expect(gregorian).to eq(gregorian2)
   end
 
+
+  it "works on bisextile a bit before" do 
+    gregorian = Date.new(2021, 11, 7)
+    ethiopian = cal.from_iso(gregorian)
+    gregorian2 = cal.to_iso(ethiopian)
+    expect(gregorian).to eq(gregorian2)
+  end  
+
+
+  it "works on bisextile and silently offset by 1 day" do 
+    gregorian = Date.new(2021, 11, 8)
+    ethiopian = cal.from_iso(gregorian)
+    gregorian2 = cal.to_iso(ethiopian)
+    expect(Date.new(2021, 11, 7)).to eq(gregorian2)
+  end
+
+  it "works on bisextile and silently offset by 2 day" do 
+    gregorian = Date.new(2021, 11, 9)
+    ethiopian = cal.from_iso(gregorian)
+    gregorian2 = cal.to_iso(ethiopian)
+    expect(Date.new(2021, 11, 7)).to eq(gregorian2)
+  end  
+
+  it "works on bisextile a bit after" do 
+    gregorian = Date.new(2021, 11, 10)
+    ethiopian = cal.from_iso(gregorian)
+    gregorian2 = cal.to_iso(ethiopian)
+    expect(gregorian).to eq(gregorian2)
+  end  
+
+
   def expect_from_ethiopian(year, month, expected)
     ethiopian = Date.new(year, month, 1)
     date = cal.to_iso(ethiopian)


### PR DESCRIPTION
the problem is the "from_iso" migth try to instantiate an invalid date in the gregorian calendar.

![image](https://user-images.githubusercontent.com/371692/140774590-cb410090-6089-4f64-b5d2-12db742b875d.png)

perhaps not the "right" fix but 
- keep the existing code okish (still behave like a date)
- we only use the year/month part of it in the rest of code 